### PR TITLE
fix: percent-decode query string (Closes #2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +294,7 @@ name = "oxyroute"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "form_urlencoded",
  "jsonwebtoken",
  "matchit",
  "once_cell",
@@ -328,6 +338,12 @@ dependencies = [
  "base64",
  "serde_core",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ thiserror = "1"
 jsonwebtoken = "9"
 base64 = "0.22"
 once_cell = "1.19"
+# RFC 1738 / WHATWG: percent-decode and + as space in application/x-www-form-urlencoded query
+form_urlencoded = "1.2"
 
 [features]
 default = []

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -15,7 +15,7 @@ handler(**kwargs)
 | Name | When present | Meaning |
 |------|----------------|--------|
 | Path parameters | Matched from the route, e.g. `id` for `/items/:id` | String-like values, with coercion for `int` / `float` / `bool` / `str` in the Rust layer where applicable |
-| `query` | Request has a query string | A Python `dict` of string keys/values (see implementation for parsing rules) |
+| `query` | Request has a query string | A Python `dict` of string keys and values, **percent-decoded**; `+` in values is treated as a space, matching `application/x-www-form-urlencoded` / URLSearchParams ([WHATWG](https://url.spec.whatwg.org/#urlencoded-parsing)). **Duplicate keys** are last-wins (a plain `dict`, not a multimap) |
 | `json` | `read_json_body` is true and body parses as JSON | `dict`/list/values as converted from `serde_json` to Python |
 | `body` | Raw body bytes, when JSON is not used or empty | `bytes` |
 | `claims` | `require_jwt` is true and the JWT validates | The decoded JSON claims as a Python object (typically a `dict`) |

--- a/src/params.rs
+++ b/src/params.rs
@@ -2,21 +2,23 @@
 
 use std::collections::HashMap;
 
+use form_urlencoded::parse as parse_urlencoded;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::IntoPy;
 
+/// Parse an HTTP `query` string (the part after `?`, without the `?`).
+/// Uses [`form_urlencoded`] so keys and values are **percent-decoded** and `+` in values is
+/// treated as a space, consistent with `application/x-www-form-urlencoded` / URLSearchParams
+/// (see [WHATWG](https://url.spec.whatwg.org/#application/x-www-form-urlencoded)). Duplicate keys
+/// are **last-wins** in the returned `HashMap` (not a multimap).
 pub fn parse_query(q: &str) -> HashMap<String, String> {
     let mut m = HashMap::new();
     if q.is_empty() {
         return m;
     }
-    for pair in q.split('&') {
-        if let Some((k, v)) = pair.split_once('=') {
-            m.insert(k.to_string(), v.to_string());
-        } else {
-            m.insert(pair.to_string(), String::new());
-        }
+    for (k, v) in parse_urlencoded(q.as_bytes()) {
+        m.insert(k.into_owned(), v.into_owned());
     }
     m
 }
@@ -66,4 +68,44 @@ pub fn header_get_lax(headers: &Bound<'_, PyAny>, name: &str) -> Option<String> 
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_query;
+
+    #[test]
+    fn decodes_percent_encoded_space() {
+        let m = parse_query("q=hello%20world");
+        assert_eq!(m.get("q").map(String::as_str), Some("hello world"));
+    }
+
+    #[test]
+    fn decodes_utf8_in_value() {
+        let m = parse_query("x=%C3%A9");
+        assert_eq!(m.get("x").map(String::as_str), Some("é"));
+    }
+
+    #[test]
+    fn plus_treated_as_space() {
+        let m = parse_query("q=a+b");
+        assert_eq!(m.get("q").map(String::as_str), Some("a b"));
+    }
+
+    #[test]
+    fn duplicate_keys_last_wins() {
+        let m = parse_query("a=1&a=2");
+        assert_eq!(m.get("a").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn empty_string_yields_empty_map() {
+        assert!(parse_query("").is_empty());
+    }
+
+    #[test]
+    fn decodes_key_and_value() {
+        let m = parse_query("k%3Dey=v%3Dalue");
+        assert_eq!(m.get("k=ey").map(String::as_str), Some("v=alue"));
+    }
 }

--- a/tests/test_query_decode.py
+++ b/tests/test_query_decode.py
@@ -1,0 +1,26 @@
+"""Query string: percent-decoding and + handling (see issue #2, src/params.rs)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from oxyroute import App
+
+
+def test_query_value_percent_decoded() -> None:
+    app = App()
+
+    @app.get("/echo")
+    def echo(**kwargs) -> str:
+        return (kwargs.get("query") or {}).get("m", "")
+
+    async def _run() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            r = await c.get("/echo?m=hello%20world")
+        assert r.status_code == 200
+        assert r.text == "hello world"
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
Implements **Issue #2**: URL-decode query keys and values using the `form_urlencoded` parser (percent-encoding + `+` as space for x-www-form-urlencoded), with Rust unit tests and an ASGI integration test.

## Commits
- `fix: percent-decode query string (form_urlencoded)` — `Cargo.toml` / `Cargo.lock`, `src/params.rs`, 6 `#[cfg(test)]` cases
- `test+docs: query decode ASGI test and handler query semantics` — `tests/test_query_decode.py`, `docs/handlers.md`

## Checklist
- [x] `cargo test` (params tests)
- [x] pytest (from /tmp, installed package)

Closes #2