### PR TITLE
feat: HTTP 500 JSON for handler/dependency errors (Closes #3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +302,7 @@ dependencies = [
  "base64",
  "form_urlencoded",
  "jsonwebtoken",
+ "log",
  "matchit",
  "once_cell",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ base64 = "0.22"
 once_cell = "1.19"
 # RFC 1738 / WHATWG: percent-decode and + as space in application/x-www-form-urlencoded query
 form_urlencoded = "1.2"
+log = "0.4"
 
 [features]
 default = []

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -38,6 +38,12 @@ The Rust layer maps the return value to an HTTP response:
 
 For precise behavior and edge cases, refer to the implementation in the repository’s `src/dispatch.rs` and `src/response.rs`.
 
+## Errors in handlers and dependencies
+
+If a **dependency factory** or the **route handler** raises a Python exception (or building the response fails), the server answers with **500** and a small **JSON** body: `{"error":"internal server error"}`. Exception text and tracebacks are **not** included in the response by default (to avoid leaking internals to clients).
+
+Set the environment variable **`OXYROUTE_DEBUG=1`** (or `true`) to include a **`detail`** string in that JSON for the same error and to log more at the `log` crate target **`oxyroute`** (see `RUST_LOG`, e.g. `RUST_LOG=oxyroute=error`).
+
 ## See also
 
 - [Routing](routing.md)

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -14,6 +14,46 @@ use crate::schema::json_to_py;
 use crate::state::{map_method_router, AppState};
 use crate::token::extract_bearer;
 
+fn oxyroute_debug() -> bool {
+    std::env::var("OXYROUTE_DEBUG")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Map Python `PyErr` to HTTP 500 with a JSON body (no exception text unless `OXYROUTE_DEBUG=1`).
+async fn send_internal_error(
+    protocol: &Py<PyAny>,
+    method: &str,
+    path: &str,
+    err: PyErr,
+) -> PyResult<PyObject> {
+    let detail_opt = if oxyroute_debug() {
+        let d = Python::with_gil(|_py| format!("{err}"));
+        let d = if d.len() > 4000 {
+            format!("{}…", &d[..4000])
+        } else {
+            d
+        };
+        log::error!(target: "oxyroute", "{method} {path} — {d}");
+        Some(d)
+    } else {
+        log::error!(target: "oxyroute", "{method} {path}: internal error (set OXYROUTE_DEBUG=1 for detail)");
+        None
+    };
+    let body = if let Some(d) = detail_opt {
+        serde_json::json!({ "error": "internal server error", "detail": d }).to_string()
+    } else {
+        r#"{"error":"internal server error"}"#.to_string()
+    };
+    response::send_text(
+        protocol,
+        500,
+        &body,
+        "application/json; charset=utf-8",
+    )
+    .await
+}
+
 pub async fn run_rsgi(
     state: Arc<Mutex<AppState>>,
     scope: Py<PyAny>,
@@ -218,23 +258,43 @@ pub async fn run_rsgi(
     let mut dep_out: Vec<PyObject> = Vec::with_capacity(dep_factories.len());
     for (i, fact) in dep_factories.iter().enumerate() {
         if dep_is_async.get(i) == Some(&true) {
-            let r = Python::with_gil(|py| -> PyResult<PyObject> {
+            let r = match Python::with_gil(|py| -> PyResult<PyObject> {
                 Ok(fact.bind(py).call((), None)?.unbind())
-            })?;
-            let fut = Python::with_gil(|py| {
+            }) {
+                Ok(x) => x,
+                Err(e) => {
+                    return send_internal_error(&protocol, &method, &path, e).await;
+                }
+            };
+            let fut = match Python::with_gil(|py| {
                 let b = r.bind(py).clone();
                 pyo3_asyncio_0_21::tokio::into_future(b)
-            })?;
-            let o = fut.await?;
+            }) {
+                Ok(f) => f,
+                Err(e) => {
+                    return send_internal_error(&protocol, &method, &path, e).await;
+                }
+            };
+            let o = match fut.await {
+                Ok(x) => x,
+                Err(e) => {
+                    return send_internal_error(&protocol, &method, &path, e).await;
+                }
+            };
             dep_out.push(o);
         } else {
-            let o = Python::with_gil(|py| -> PyResult<PyObject> {
+            let o = match Python::with_gil(|py| -> PyResult<PyObject> {
                 Ok(fact.bind(py).call((), None)?.unbind())
-            })?;
+            }) {
+                Ok(x) => x,
+                Err(e) => {
+                    return send_internal_error(&protocol, &method, &path, e).await;
+                }
+            };
             dep_out.push(o);
         }
     }
-    let (res, run_async) = Python::with_gil(|py| -> PyResult<(PyObject, bool)> {
+    let (res, run_async) = match Python::with_gil(|py| -> PyResult<(PyObject, bool)> {
         let kwargs = PyDict::new_bound(py);
         for (k, v) in param_map {
             let vpy = value_for_path_param(py, &v);
@@ -268,17 +328,32 @@ pub async fn run_rsgi(
             .call((), Some(&kwargs))?
             .unbind();
         Ok((res, is_async))
-    })?;
+    }) {
+        Ok(x) => x,
+        Err(e) => {
+            return send_internal_error(&protocol, &method, &path, e).await;
+        }
+    };
     let handler_out: PyObject = if run_async {
-        let fut = Python::with_gil(|py| {
+        let fut = match Python::with_gil(|py| {
             let b = res.bind(py).clone();
             pyo3_asyncio_0_21::tokio::into_future(b)
-        })?;
-        fut.await?
+        }) {
+            Ok(f) => f,
+            Err(e) => {
+                return send_internal_error(&protocol, &method, &path, e).await;
+            }
+        };
+        match fut.await {
+            Ok(x) => x,
+            Err(e) => {
+                return send_internal_error(&protocol, &method, &path, e).await;
+            }
+        }
     } else {
         res
     };
-    let (status, bytes, content_type) = Python::with_gil(|py| -> PyResult<(u16, Vec<u8>, String)> {
+    let (status, bytes, content_type) = match Python::with_gil(|py| -> PyResult<(u16, Vec<u8>, String)> {
         let b = handler_out.bind(py);
         if let Ok(s) = b.extract::<String>() {
             return Ok((200, s.into_bytes(), "text/plain; charset=utf-8".to_string()));
@@ -302,6 +377,11 @@ pub async fn run_rsgi(
         let dumped = jmod.call_method1("dumps", (b.clone().unbind(),))?;
         let s: String = dumped.extract()?;
         Ok((200, s.into_bytes(), "application/json; charset=utf-8".to_string()))
-    })?;
+    }) {
+        Ok(x) => x,
+        Err(e) => {
+            return send_internal_error(&protocol, &method, &path, e).await;
+        }
+    };
     response::send_bytes(&protocol, status, &bytes, &content_type).await
 }

--- a/tests/test_handler_errors_500.py
+++ b/tests/test_handler_errors_500.py
@@ -1,0 +1,78 @@
+"""Handler / dependency exceptions map to HTTP 500 (issue #3)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import httpx
+
+from oxyroute import App
+
+
+def _make_app() -> App:
+    app = App()
+
+    @app.get("/boom")
+    def boom() -> str:
+        raise ValueError("super_secret_token")
+
+    def bad_dep() -> str:
+        raise RuntimeError("dep fail")
+
+    @app.get("/dep", dependencies=[("x", bad_dep)])
+    def with_dep(x: str) -> str:  # pragma: no cover - dep fails first
+        return x
+
+    return app
+
+
+def test_500_no_exception_text_by_default() -> None:
+    os.environ.pop("OXYROUTE_DEBUG", None)
+    app = _make_app()
+
+    async def _run() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/boom")
+        assert r.status_code == 500
+        data = json.loads(r.text)
+        assert data.get("error") == "internal server error"
+        assert "detail" not in data
+        assert "super_secret" not in r.text
+
+    asyncio.run(_run())
+
+
+def test_500_includes_detail_when_debug_env() -> None:
+    os.environ["OXYROUTE_DEBUG"] = "1"
+    app = _make_app()
+    try:
+
+        async def _run() -> None:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+                r = await c.get("/boom")
+            assert r.status_code == 500
+            data = json.loads(r.text)
+            assert "detail" in data
+            assert "super_secret_token" in data["detail"] or "ValueError" in data["detail"]
+
+        asyncio.run(_run())
+    finally:
+        os.environ.pop("OXYROUTE_DEBUG", None)
+
+
+def test_dependency_error_returns_500() -> None:
+    os.environ.pop("OXYROUTE_DEBUG", None)
+    app = _make_app()
+
+    async def _run() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/dep")
+        assert r.status_code == 500
+        assert "internal" in r.text.lower()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Maps Python `PyErr` from dependency factories, handler invocation, coroutine await, and response mapping to **HTTP 500** with `application/json` (`{\"error\":\"internal server error\"}` by default).
- `OXYROUTE_DEBUG=1` adds a `detail` string and uses `log` (target `oxyroute`) with method/path.
- Truncates `detail` to 4000 chars + ellipsis.

## Commits
- `feat: return JSON 500 on handler and dependency PyErr` — `log` + `src/dispatch.rs`
- `test+docs: 500 error handling and OXYROUTE_DEBUG`

## How to test
- `pytest tests/test_handler_errors_500.py` (ASGI) from a directory where the **installed** package is used.

Closes #3