### PR TITLE
feat: add App.patch() decorator (P1 #1)

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -11,7 +11,7 @@ OxyRoute uses the **[matchit](https://crates.io/crates/matchit) 0.7** style of p
 
 The Python `App` class exposes:
 
-- `get`, `post`, `put`, `delete`
+- `get`, `post`, `put`, `patch`, `delete`
 
 Each is a decorator that registers a route and returns the handler unchanged (so you can stack multiple decorators on the same function only if you design for it—usually one method/path per handler is enough).
 

--- a/oxyroute/app.py
+++ b/oxyroute/app.py
@@ -94,6 +94,20 @@ class App:
             "PUT", path, require_jwt, jwt_secret, algorithms, read_json_body=True, dependencies=dependencies
         )
 
+    def patch(
+        self,
+        path: str,
+        *,
+        require_jwt: bool = False,
+        jwt_secret: Optional[str] = None,
+        algorithms: Optional[List[str]] = None,
+        read_json_body: bool = True,
+        dependencies: Optional[List[Tuple[str, Dep]]] = None,
+    ) -> Callable[[F], F]:
+        return self._route(
+            "PATCH", path, require_jwt, jwt_secret, algorithms, read_json_body, dependencies=dependencies
+        )
+
     def delete(
         self,
         path: str,

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -23,3 +23,20 @@ def test_asgi_get_plain_text() -> None:
         assert r2.text == "x"
 
     asyncio.run(_run())
+
+
+def test_asgi_patch_json_body() -> None:
+    app = App()
+
+    @app.patch("/x")
+    def patch_x(json: dict) -> str:  # noqa: A002 — injected JSON body
+        return f"p:{json.get('a')}"
+
+    async def _run() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            r = await c.patch("/x", json={"a": 7})
+        assert r.status_code == 200
+        assert r.text == "p:7"
+
+    asyncio.run(_run())

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,3 +1,5 @@
+import json
+
 from oxyroute import App
 
 
@@ -10,3 +12,14 @@ def test_openapi_shows_route() -> None:
     assert "paths" in s
     assert "/items/:i" in s
     assert "T" in s
+
+
+def test_openapi_includes_patch_lowercase() -> None:
+    app = App()
+
+    @app.patch("/m")
+    def m() -> str:
+        return "ok"
+
+    doc = json.loads(app.openapi_json())
+    assert doc["paths"]["/m"]["patch"]["operationId"] == "m"


### PR DESCRIPTION
Mirror put defaults (read_json_body=True). Register PATCH in Rust router. Document in routing.md; add ASGI and OpenAPI tests.