### PR TITLE
feat: JWT from Cookie header (issue #7)

### DIFF
--- a/docs/jwt.md
+++ b/docs/jwt.md
@@ -8,7 +8,8 @@ OxyRoute can validate **Bearer JWTs** in the **Rust** layer for routes you mark 
 
 The HTTP verb decorators on `App` accept:
 
-- `require_jwt: bool` — if true, a valid `Authorization: Bearer <token>` header and successful verification are required before the handler runs
+- `require_jwt: bool` — if true, a valid JWT and successful verification are required before the handler runs (see below)
+- `jwt_cookie: str | None` — if set, and there is no usable `Authorization: Bearer` value, the token is read from the `Cookie` header: the first non-empty `name=<value>` pair where `name` matches this string (case-sensitive). `Bearer` still wins when both are present
 - `jwt_secret: str | None` — required for the default HMAC flow when `require_jwt` is set
 - `algorithms: list[str] | None` — e.g. `["HS256"]` (defaults in code if omitted)
 - `jwt_issuer: str | None` — if set, the `iss` claim must match (via [`jsonwebtoken`](https://crates.io/crates/jsonwebtoken) validation)
@@ -22,7 +23,7 @@ If `require_jwt` is set but the secret is missing for an all-HMAC algorithm set,
 The handler is **not** executed when:
 
 - The route requires JWT but there is no usable secret
-- The `Authorization` header is missing or not a Bearer token
+- The `Authorization` header is not a usable Bearer token **and** there is no `jwt_cookie` value, or the named cookie is missing/empty; otherwise cookie-based token is used when `jwt_cookie` is set
 - The token does not verify (including wrong algorithm/secret) — typically **401** with a plain `Unauthorized` body
 - The token is expired in a way the library classifies as signature expiry — **401** with body `Expired` in the current implementation
 

--- a/oxyroute/app.py
+++ b/oxyroute/app.py
@@ -59,6 +59,7 @@ class App:
         jwt_issuer: str | None = None,
         jwt_audience: str | None = None,
         jwt_leeway: int | None = None,
+        jwt_cookie: str | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -72,6 +73,7 @@ class App:
             jwt_issuer=jwt_issuer,
             jwt_audience=jwt_audience,
             jwt_leeway=jwt_leeway,
+            jwt_cookie=jwt_cookie,
         )
 
     def post(
@@ -85,6 +87,7 @@ class App:
         jwt_issuer: str | None = None,
         jwt_audience: str | None = None,
         jwt_leeway: int | None = None,
+        jwt_cookie: str | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -98,6 +101,7 @@ class App:
             jwt_issuer=jwt_issuer,
             jwt_audience=jwt_audience,
             jwt_leeway=jwt_leeway,
+            jwt_cookie=jwt_cookie,
         )
 
     def put(
@@ -110,6 +114,7 @@ class App:
         jwt_issuer: str | None = None,
         jwt_audience: str | None = None,
         jwt_leeway: int | None = None,
+        jwt_cookie: str | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -123,6 +128,7 @@ class App:
             jwt_issuer=jwt_issuer,
             jwt_audience=jwt_audience,
             jwt_leeway=jwt_leeway,
+            jwt_cookie=jwt_cookie,
         )
 
     def patch(
@@ -136,6 +142,7 @@ class App:
         jwt_issuer: str | None = None,
         jwt_audience: str | None = None,
         jwt_leeway: int | None = None,
+        jwt_cookie: str | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -149,6 +156,7 @@ class App:
             jwt_issuer=jwt_issuer,
             jwt_audience=jwt_audience,
             jwt_leeway=jwt_leeway,
+            jwt_cookie=jwt_cookie,
         )
 
     def delete(
@@ -161,6 +169,7 @@ class App:
         jwt_issuer: str | None = None,
         jwt_audience: str | None = None,
         jwt_leeway: int | None = None,
+        jwt_cookie: str | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -174,6 +183,7 @@ class App:
             jwt_issuer=jwt_issuer,
             jwt_audience=jwt_audience,
             jwt_leeway=jwt_leeway,
+            jwt_cookie=jwt_cookie,
         )
 
     def options(
@@ -186,6 +196,7 @@ class App:
         jwt_issuer: str | None = None,
         jwt_audience: str | None = None,
         jwt_leeway: int | None = None,
+        jwt_cookie: str | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -199,6 +210,7 @@ class App:
             jwt_issuer=jwt_issuer,
             jwt_audience=jwt_audience,
             jwt_leeway=jwt_leeway,
+            jwt_cookie=jwt_cookie,
         )
 
     def _route(
@@ -214,6 +226,7 @@ class App:
         jwt_issuer: str | None = None,
         jwt_audience: str | None = None,
         jwt_leeway: int | None = None,
+        jwt_cookie: str | None = None,
     ) -> Callable[[F], F]:
         dlist = _norm_dependencies(dependencies)
 
@@ -230,6 +243,7 @@ class App:
                 jwt_issuer,
                 jwt_audience,
                 jwt_leeway,
+                jwt_cookie,
             )
             return handler
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -12,7 +12,7 @@ use crate::params::{build_request_context, header_get_lax, parse_query, value_fo
 use crate::response;
 use crate::schema::json_to_py;
 use crate::state::{map_method_router, methods_matching_path, AppState};
-use crate::token::extract_bearer;
+use crate::token::{extract_bearer, extract_cookie_value};
 
 fn oxyroute_debug() -> bool {
     std::env::var("OXYROUTE_DEBUG")
@@ -111,11 +111,15 @@ pub async fn run_rsgi(
         }
         Ok(Vec::new())
     })?;
-    let auth = Python::with_gil(|py| -> PyResult<Option<String>> {
-        let s = scope.bind(py);
-        let headers = s.getattr("headers")?;
-        Ok(header_get_lax(&headers, "authorization"))
-    })?;
+    let (auth, cookie_raw) =
+        Python::with_gil(|py| -> PyResult<(Option<String>, Option<String>)> {
+            let s = scope.bind(py);
+            let headers = s.getattr("headers")?;
+            Ok((
+                header_get_lax(&headers, "authorization"),
+                header_get_lax(&headers, "cookie"),
+            ))
+        })?;
     let route_out: Option<(usize, HashMap<String, String>)> = (|| -> PyResult<_> {
         let st = state.lock().map_err(crate::lock_err)?;
         let g = map_method_router(&st, &method)
@@ -156,6 +160,7 @@ pub async fn run_rsgi(
         jwt_issuer,
         jwt_audience,
         jwt_leeway,
+        jwt_cookie,
         read_json_body,
         dep_names,
         dep_factories,
@@ -178,6 +183,7 @@ pub async fn run_rsgi(
             e.jwt_issuer.clone(),
             e.jwt_audience.clone(),
             e.jwt_leeway,
+            e.jwt_cookie.clone(),
             e.read_json_body,
             e.dep_names.clone(),
             e.dep_factories.clone(),
@@ -201,17 +207,31 @@ pub async fn run_rsgi(
             }
             Some(s) => s,
         };
-        let token = match extract_bearer(auth.as_deref()) {
+        let token: String = match extract_bearer(auth.as_deref()).filter(|s| !s.is_empty()) {
             Some(t) => t,
-            None => {
-                return response::send_text(
-                    &protocol,
-                    401,
-                    "Unauthorized",
-                    "text/plain; charset=utf-8",
-                )
-                .await
-            }
+            None => match (jwt_cookie.as_deref(), cookie_raw.as_deref()) {
+                (Some(cname), Some(raw)) => match extract_cookie_value(raw, cname) {
+                    Some(t) if !t.is_empty() => t,
+                    _ => {
+                        return response::send_text(
+                            &protocol,
+                            401,
+                            "Unauthorized",
+                            "text/plain; charset=utf-8",
+                        )
+                        .await;
+                    }
+                },
+                _ => {
+                    return response::send_text(
+                        &protocol,
+                        401,
+                        "Unauthorized",
+                        "text/plain; charset=utf-8",
+                    )
+                    .await;
+                }
+            },
         };
         let mut val = if let Some(f) = algs.first() {
             Validation::new(*f)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl App {
 
     /// Paths use **matchit 0.7** style: `/user/:id`. Pass `dependencies=[("x", get_x), ...]`.
     #[pyo3(
-        signature = (method, path, handler, require_jwt=false, jwt_secret=None, algorithms=None, read_json_body=true, dependencies=None, jwt_issuer=None, jwt_audience=None, jwt_leeway=None)
+        signature = (method, path, handler, require_jwt=false, jwt_secret=None, algorithms=None, read_json_body=true, dependencies=None, jwt_issuer=None, jwt_audience=None, jwt_leeway=None, jwt_cookie=None)
     )]
     #[allow(clippy::too_many_arguments)]
     fn add_route(
@@ -157,6 +157,7 @@ impl App {
         jwt_issuer: Option<String>,
         jwt_audience: Option<String>,
         jwt_leeway: Option<u64>,
+        jwt_cookie: Option<String>,
     ) -> PyResult<()> {
         let st = self.state.lock().map_err(lock_err)?;
         if st.frozen {
@@ -216,6 +217,7 @@ impl App {
             jwt_issuer,
             jwt_audience,
             jwt_leeway: jwt_leeway.unwrap_or(60),
+            jwt_cookie,
             read_json_body,
             dep_names,
             dep_factories,

--- a/src/state.rs
+++ b/src/state.rs
@@ -16,6 +16,8 @@ pub struct RouteEntry {
     pub jwt_audience: Option<String>,
     /// Clock skew (seconds); Python `None` uses default 60 (jsonwebtoken default).
     pub jwt_leeway: u64,
+    /// If set, read JWT from the `Cookie` header when `Authorization: Bearer` is missing.
+    pub jwt_cookie: Option<String>,
     pub read_json_body: bool,
     /// Dependency `name` -> factory callable (linear order; resolved in order, then user handler).
     pub dep_names: Vec<String>,

--- a/src/token.rs
+++ b/src/token.rs
@@ -16,6 +16,38 @@ pub fn extract_bearer(h: Option<&str>) -> Option<String> {
     }
 }
 
+/// Read a case-sensitive cookie name from a raw [`Cookie`][1] header value.
+///
+/// [1]: https://www.rfc-editor.org/rfc/rfc6265#section-4.2.1
+pub fn extract_cookie_value(raw: &str, name: &str) -> Option<String> {
+    for part in raw.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (k, v) = part.split_once('=')?;
+        if k.trim() != name {
+            continue;
+        }
+        let v = v.trim();
+        let v = trim_cookie_dquotes(v);
+        if v.is_empty() {
+            return None;
+        }
+        return Some(v.to_string());
+    }
+    None
+}
+
+fn trim_cookie_dquotes(s: &str) -> &str {
+    let s = s.trim();
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
 /// Used by the request path and for golden tests against `oxyjwt.decode`.
 pub fn decode_hs_claims(
     token: &str,
@@ -72,4 +104,25 @@ pub fn decode_jwt_hs(
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
     let j = py.import_bound("json")?;
     Ok(j.call_method1("loads", (s,))?.unbind())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_cookie_finds_name() {
+        assert_eq!(
+            extract_cookie_value("a=1; access_token=eyJ.x.y; Path=/", "access_token").as_deref(),
+            Some("eyJ.x.y")
+        );
+    }
+
+    #[test]
+    fn extract_cookie_quoted() {
+        assert_eq!(
+            extract_cookie_value(r#"t="a.b.c""#, "t").as_deref(),
+            Some("a.b.c")
+        );
+    }
 }

--- a/tests/test_jwt_cookie.py
+++ b/tests/test_jwt_cookie.py
@@ -1,0 +1,93 @@
+"""JWT from Cookie when Bearer is missing (issue #7)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+import pytest
+from oxyroute import App
+
+oxyjwt = pytest.importorskip("oxyjwt")
+
+SECRET = "ck-secret"
+COOKIE_NAME = "access_token"
+
+
+def _token() -> str:
+    now = int(time.time())
+    return oxyjwt.encode(  # type: ignore[no-untyped-call]
+        {"sub": "c1", "exp": now + 3600},
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+def test_jwt_from_cookie() -> None:
+    app = App()
+
+    @app.get(
+        "/c",
+        require_jwt=True,
+        jwt_secret=SECRET,
+        algorithms=["HS256"],
+        jwt_cookie=COOKIE_NAME,
+    )
+    def c(claims: dict) -> str:
+        return claims.get("sub", "")
+
+    tok = _token()
+
+    async def run() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.get(
+                "/c",
+                headers={"Cookie": f"other=1; {COOKIE_NAME}={tok}"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.text == "c1"
+
+    asyncio.run(run())
+
+
+def test_bearer_wins_over_cookie() -> None:
+    app = App()
+
+    @app.get(
+        "/b",
+        require_jwt=True,
+        jwt_secret=SECRET,
+        algorithms=["HS256"],
+        jwt_cookie=COOKIE_NAME,
+    )
+    def b(claims: dict) -> str:
+        return str(claims.get("sub", ""))
+
+    now = int(time.time())
+    bearer_tok = oxyjwt.encode(  # type: ignore[no-untyped-call]
+        {"sub": "from-bearer", "exp": now + 3600},
+        SECRET,
+        algorithm="HS256",
+    )
+    cook_tok = oxyjwt.encode(  # type: ignore[no-untyped-call]
+        {"sub": "from-cookie", "exp": now + 3600},
+        SECRET,
+        algorithm="HS256",
+    )
+
+    async def run() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.get(
+                "/b",
+                headers={
+                    "Authorization": f"Bearer {bearer_tok}",
+                    "Cookie": f"{COOKIE_NAME}={cook_tok}",
+                },
+            )
+        assert r.status_code == 200
+        assert r.text == "from-bearer"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- `jwt_cookie: str | None` on all route decorators: if set, and `Authorization: Bearer` is missing or empty, the token is taken from the `Cookie` header (case-sensitive name, `;`-separated pairs).
- `Authorization: Bearer` still takes precedence when present.
- `token::extract_cookie_value` + unit tests; ASGI tests with oxyjwt.
- `docs/jwt.md` updated.

Closes #7