### PR TITLE
docs+example+test: RSGI lifespan / per-worker state (issue #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Run (from the repo, after `maturin develop` or an editable install):
 granian --interface rsgi examples.rsgi_app:app
 ```
 
+Per-worker setup (`__rsgi_init__`) is shown in [examples/rsgi_lifespan_app.py](examples/rsgi_lifespan_app.py) and [docs/rsgi.md](docs/rsgi.md#lifespan-optional).
+
 ASGI and other servers are covered in [docs/asgi.md](docs/asgi.md).
 
 ## Project layout

--- a/docs/rsgi.md
+++ b/docs/rsgi.md
@@ -20,10 +20,36 @@ The Python `oxyroute.app.App` class implements the async RSGI entry that Granian
 
 `App` defines no-op coroutines for servers that expect them. Implementations use `*args, **kwargs` so **Granian** (and any server that passes extra parameters to worker lifespan hooks) can call them without a `TypeError`:
 
-- `async def __rsgi_init__(self, *args, **kwargs) -> None`
-- `async def __rsgi_del__(self, *args, **kwargs) -> None`
+- `async def __rsgi_init__(self, *args, **kwargs) -> None` — per-worker (or per-process) **startup** in the RSGI host
+- `async def __rsgi_del__(self, *args, **kwargs) -> None` — **teardown** when the worker stops
 
-You can override these in a subclass if you need startup/shutdown hooks; the default does nothing.
+You can **override** these in a **subclass** of `App` to open DB pools, HTTP clients, `asyncio` primitives, etc. The default base implementation does nothing.
+
+### Workers and shared state (Granian)
+
+- With **`granian --workers N`**, the server runs **N independent worker processes** (typical for CPU-bound HTTP). Each process loads your module, constructs your `app`, and may call `__rsgi_init__` **once per worker** (exact call pattern is defined by the server; see [Granian’s docs](https://github.com/emmett-framework/granian)). **In-memory** attributes you set in `__rsgi_init__` are **not** shared between workers: two requests may hit different processes and see different `self.foo`.
+- If you use **a single worker** or run under **in-process** tests, one process is enough for a module-level or `self` cache for development only.
+- For **user sessions, counts, or singletons** across the whole deployment, use **external** storage (Postgres, Redis, etc.); a DB **connection pool** created in `__rsgi_init__` is still a good pattern: one pool **per process**, many requests share connections inside that pool.
+
+### Factory pattern
+
+As an alternative to a subclass, you can expose `app` from a factory:
+
+```python
+def create_app() -> App:
+    a = App(title="x")
+    # register routes on `a` …
+    return a
+
+app = create_app()
+```
+
+`granian` imports `app` once per worker, so the factory runs in each process that loads the module.
+
+### Example in the repository
+
+- [`examples/rsgi_app.py`](../examples/rsgi_app.py) — minimal RSGI app  
+- [`examples/rsgi_lifespan_app.py`](../examples/rsgi_lifespan_app.py) — subclass with `__rsgi_init__` / `__rsgi_del__` and `ready_at` used from handlers
 
 ## When to use ASGI instead
 

--- a/examples/rsgi_lifespan_app.py
+++ b/examples/rsgi_lifespan_app.py
@@ -1,0 +1,55 @@
+"""
+Per-worker RSGI lifecycle: override ``__rsgi_init__`` / ``__rsgi_del__`` (issue #18).
+
+Run (from the repo root after an editable / wheel install)::
+
+    granian --interface rsgi examples.rsgi_lifespan_app:app
+
+``examples/rsgi_app.py`` is the minimal app. This file shows **subclassing** ``App`` to
+open resources when the host starts a worker. In-memory fields are **per OS process**;
+with ``granian --workers N`` each worker has its own object graph — use Redis, a DB
+pool, or a message bus for **cross-worker** or **cross-machine** state.
+
+See https://github.com/QueryaHub/OxyRoute/blob/main/docs/rsgi.md (lifespan section).
+"""
+
+from __future__ import annotations
+
+import time
+
+from oxyroute import App
+
+
+class LifespanApp(App):
+    """Example: set attributes when the RSGI worker calls ``__rsgi_init__``."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ready_at: float | None = None
+
+    async def __rsgi_init__(self, *args, **kwargs) -> None:
+        # Place per-process setup here (DB engine, pool, clients, asyncio primitives).
+        self.ready_at = time.time()
+        return None
+
+    async def __rsgi_del__(self, *args, **kwargs) -> None:
+        self.ready_at = None
+        return None
+
+
+app = LifespanApp(title="Lifespan example")
+
+
+@app.get("/")
+def root() -> str:
+    t = app.ready_at
+    if t is None:
+        return "ok (lifespan not run — use a real RSGI server)"
+    return f"ok boot_timestamp={t:.4f}"
+
+
+@app.get("/meta")
+def meta() -> str:
+    """In multi-worker mode each worker has its own ``ready_at`` (not a global counter)."""
+    t = app.ready_at
+    return f"ready_at={t}"

--- a/oxyroute/app.py
+++ b/oxyroute/app.py
@@ -273,11 +273,14 @@ class App:
         return wrap
 
     async def __rsgi_init__(self, *args: Any, **kwargs: Any) -> None:
-        """Lifespan hook (no-op). Granian may pass extra positional args; accept **kwargs."""
+        """
+        RSGI worker startup (no-op in the base class). Subclass to open pools/clients; see
+        ``docs/rsgi.md`` (Lifespan) and ``examples/rsgi_lifespan_app.py``.
+        """
         return None
 
     async def __rsgi_del__(self, *args: Any, **kwargs: Any) -> None:
-        """Lifespan teardown (no-op). Accept extra args for Granian compatibility."""
+        """RSGI worker teardown (no-op in the base class)."""
         return None
 
     async def __rsgi__(self, scope: Any, protocol: Any) -> None:

--- a/tests/test_rsgi_lifespan.py
+++ b/tests/test_rsgi_lifespan.py
@@ -1,0 +1,31 @@
+"""RSGI lifespan hooks: subclassing ``App`` (issue #18)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from oxyroute import App
+
+
+def test_base_rsgi_init_and_del_are_noop() -> None:
+    async def _go() -> None:
+        a = App()
+        await a.__rsgi_init__()
+        await a.__rsgi_del__()
+
+    asyncio.run(_go())
+
+
+def test_subclass_rsgi_init_can_set_state() -> None:
+    class WorkerApp(App):
+        async def __rsgi_init__(self, *args, **kwargs) -> None:
+            self.marker = 7
+            return None
+
+    async def _go() -> None:
+        a = WorkerApp()
+        assert not hasattr(a, "marker")
+        await a.__rsgi_init__()
+        assert a.marker == 7
+
+    asyncio.run(_go())


### PR DESCRIPTION
Closes #18

- `examples/rsgi_lifespan_app.py`: subclass `App` with `__rsgi_init__` / `__rsgi_del__` and in-memory `ready_at`
- `docs/rsgi.md`: workers vs shared state, `create_app` factory, links to both examples
- `tests/test_rsgi_lifespan.py`: base hooks + subclass can set `self` in init
- README + `App` docstrings for discoverability