### PR TITLE
ci: PyPI release on v* tags (trusted publishing, issue #14)

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,131 @@
+# Publish wheels + sdist to PyPI on version tags (trusted publishing / OIDC).
+# One-time PyPI setup: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+# GitHub: create an Environment named `pypi` (this workflow uses it for the publish job).
+
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: pypi-release-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sdist:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        env:
+          CARGO_INCREMENTAL: "0"
+        with:
+          command: sdist
+          args: --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oxyroute-release-sdist
+          path: dist
+
+  wheels-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Linux wheels
+        uses: PyO3/maturin-action@v1
+        env:
+          CARGO_INCREMENTAL: "0"
+        with:
+          target: x86_64
+          manylinux: auto
+          args: --release --out dist --locked --compatibility pypi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oxyroute-release-linux
+          path: dist
+
+  wheels-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          architecture: x64
+      - name: Build Windows wheels
+        uses: PyO3/maturin-action@v1
+        env:
+          CARGO_INCREMENTAL: "0"
+        with:
+          target: x64
+          args: --release --out dist --locked --compatibility pypi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oxyroute-release-windows
+          path: dist
+
+  wheels-macos-aarch64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build macOS (arm64) wheels
+        uses: PyO3/maturin-action@v1
+        env:
+          CARGO_INCREMENTAL: "0"
+        with:
+          target: aarch64
+          args: --release --out dist --locked --compatibility pypi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oxyroute-release-macos-aarch64
+          path: dist
+
+  wheels-macos-x86_64:
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build macOS (x86_64) wheels
+        uses: PyO3/maturin-action@v1
+        env:
+          CARGO_INCREMENTAL: "0"
+        with:
+          target: x86_64
+          args: --release --out dist --locked --compatibility pypi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oxyroute-release-macos-x86_64
+          path: dist
+
+  publish:
+    name: Upload to PyPI
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - sdist
+      - wheels-linux
+      - wheels-windows
+      - wheels-macos-aarch64
+      - wheels-macos-x86_64
+    runs-on: ubuntu-22.04
+    environment:
+      name: pypi
+      url: https://pypi.org/project/oxyroute/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+          pattern: oxyroute-release-*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          print-hash: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,6 +51,19 @@ The workflow at `.github/workflows/ci.yml` (job name: **ci**):
 - Matrix across **OS** (Ubuntu, macOS, Windows) and **Python** 3.10 through 3.14 (see `.github/workflows/ci.yml`)
 - Installs dev dependencies (including **granian**), builds a release wheel, installs it, and runs the full pytest suite as above
 
+## Releasing to PyPI
+
+Tag a release with a **`v`-prefixed** semver tag (example: `v0.2.0`). That triggers `.github/workflows/release-pypi.yml`, which builds an **sdist**, **manylinux** x86_64 wheels, **Windows** x64, and **macOS** arm64 + x86_64 wheels, then uploads everything to **PyPI** using [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no long-lived API token in the workflow).
+
+**Before the first upload:**
+
+1. Keep **`pyproject.toml`** / **`Cargo.toml`** versions in sync with the tag you push.
+2. On **PyPI**, register the project (if new) and add a **trusted publisher** for this repo: GitHub → org/repo → workflow **`release-pypi.yml`** → job **`publish`**, and the GitHub **environment** name **`pypi`** (see [PyPI: adding a publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)).
+3. In the GitHub repository, create an **environment** named **`pypi`** (Settings → Environments). You can leave protection rules empty or require reviewers for production safety.
+4. Optionally dry-run on [TestPyPI](https://test.pypi.org/) first: add a second trusted publisher for Test PyPI and either a separate workflow or a manual `twine upload` — the stock release workflow targets production PyPI only.
+
+Build jobs set **`CARGO_INCREMENTAL=0`** for more reproducible release artifacts; wheel builds use **`--locked`** with the committed **`Cargo.lock`**.
+
 ## See also
 
 - [Installation](installation.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Granian still invokes a Python `App` object; the “win” is doing routing, bod
 | [Dependencies](dependencies.md) | `Depends`, `dependencies=[...]`, `freeze` |
 | [OpenAPI](openapi.md) | `openapi.json` route, title, `openapi_json()` |
 | [ASGI bridge](asgi.md) | Optional `__call__` for ASGI 3, limitations |
-| [Development](development.md) | Tests, CI, clippy, running pytest safely |
+| [Development](development.md) | Tests, CI, PyPI releases (tag `v*`), clippy, pytest |
 | [Branching and PRs](development-workflow.md) | `dev` as base, issue branches, `Closes #N`, no mixing code with `ISSUE_BACKLOG` in one commit |
 | [Contributing](../CONTRIBUTING.md) | Local setup, issue backlog, GitHub `gh` workflow |
 


### PR DESCRIPTION
Closes #14

- `.github/workflows/release-pypi.yml`: on push to tag `v*`, build sdist + manylinux x86_64 + Windows x64 + macOS aarch64 + macOS x86_64, then `pypa/gh-action-pypi-publish@release/v1` with OIDC (`id-token: write`, GitHub Environment `pypi`).
- Build jobs: `CARGO_INCREMENTAL=0`; wheels use `--locked` and `--compatibility pypi`.
- `docs/development.md`: one-time PyPI trusted-publisher and GitHub `pypi` environment steps; `docs/index.md` tweak.

**Maintainer follow-up (not in repo):** create Environment `pypi` on GitHub; on pypi.org add trusted publisher for workflow `release-pypi.yml` / job `publish` / env `pypi`. Optionally test with TestPyPI using a second publisher (see doc).