### PR TITLE
perf: RwLock for AppState to cut request-path contention (issue #4)

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 
 use jsonwebtoken::errors::ErrorKind;
 use jsonwebtoken::{decode, DecodingKey, Validation};
@@ -50,7 +50,7 @@ async fn send_internal_error(
 }
 
 pub async fn run_rsgi(
-    state: Arc<Mutex<AppState>>,
+    state: Arc<RwLock<AppState>>,
     scope: Py<PyAny>,
     protocol: Py<PyAny>,
 ) -> PyResult<PyObject> {
@@ -74,7 +74,7 @@ pub async fn run_rsgi(
     let is_head = method == "HEAD";
     if (method == "GET" || method == "HEAD") && path == "/openapi.json" {
         let (inc, doc) = {
-            let st = state.lock();
+            let st = state.read();
             if !st.include_openapi {
                 (false, String::new())
             } else {
@@ -97,7 +97,7 @@ pub async fn run_rsgi(
         }
     }
     let maybe_mw = {
-        let st = state.lock();
+        let st = state.read();
         st.middleware.clone()
     };
     if let Some(mw) = maybe_mw {
@@ -148,7 +148,7 @@ pub async fn run_rsgi(
             ))
         })?;
     let route_out: Option<(usize, HashMap<String, String>)> = (|| -> PyResult<_> {
-        let st = state.lock();
+        let st = state.read();
         let g = map_method_router(&st, &method)
             .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("method"))?;
         Ok(g.at(&path).ok().map(|m| {
@@ -163,7 +163,7 @@ pub async fn run_rsgi(
         Some(x) => x,
         None => {
             let m = {
-                let st = state.lock();
+                let st = state.read();
                 methods_matching_path(&st, &path)
             };
             if m.is_empty() {
@@ -196,7 +196,7 @@ pub async fn run_rsgi(
         handler_param_names,
         handler_varkw,
     ) = {
-        let st = state.lock();
+        let st = state.read();
         let e = st
             .routes
             .get(route_idx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
@@ -101,7 +101,7 @@ fn dependency_wants_request(py: Python<'_>, f: &Bound<'_, PyAny>) -> PyResult<bo
 
 #[pyclass]
 pub struct App {
-    state: Arc<Mutex<AppState>>,
+    state: Arc<RwLock<AppState>>,
 }
 
 impl App {
@@ -155,7 +155,7 @@ impl App {
         let mut s = AppState::new();
         s.include_openapi = include_openapi;
         Self {
-            state: Arc::new(Mutex::new(s)),
+            state: Arc::new(RwLock::new(s)),
         }
     }
 
@@ -181,13 +181,14 @@ impl App {
         jwt_cookie: Option<String>,
         body_schema_json: Option<String>,
     ) -> PyResult<()> {
-        let st = self.state.lock();
-        if st.frozen {
-            return Err(pyo3::exceptions::PyValueError::new_err(
-                "app is frozen; no more add_route",
-            ));
+        {
+            let st = self.state.read();
+            if st.frozen {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "app is frozen; no more add_route",
+                ));
+            }
         }
-        drop(st);
         let inspect = py.import_bound("inspect")?;
         let f = inspect.getattr("iscoroutinefunction")?;
         let is_async: bool = f.call1((handler.clone_ref(py),))?.extract()?;
@@ -228,7 +229,7 @@ impl App {
             .getattr(pyo3::intern!(py, "__name__"))?
             .extract()?;
         let (handler_param_names, handler_varkw) = handler_signature_kinds(py, handler.bind(py))?;
-        let mut st = self.state.lock();
+        let mut st = self.state.write();
         let idx = st.routes.len();
         st.routes.push(state::RouteEntry {
             handler,
@@ -273,19 +274,19 @@ impl App {
 
     /// Lock route registration. Linear dependency list is a valid topological order (DAG of independent roots).
     fn freeze(&self) -> PyResult<()> {
-        let mut st = self.state.lock();
+        let mut st = self.state.write();
         st.frozen = true;
         Ok(())
     }
 
     fn set_openapi_served(&self, enabled: bool) -> PyResult<()> {
-        let mut st = self.state.lock();
+        let mut st = self.state.write();
         st.include_openapi = enabled;
         Ok(())
     }
 
     fn set_openapi_title(&self, title: &str) -> PyResult<()> {
-        let st = self.state.lock();
+        let st = self.state.read();
         let mut oa = st.openapi.lock();
         if let Some(info) = oa
             .as_object_mut()
@@ -300,7 +301,7 @@ impl App {
     /// Single optional pre-route hook. Return ``None`` to continue; otherwise the return value
     /// is mapped like a route handler (e.g. :class:`oxyroute.Response`, ``dict`` with ``status`` / ``body`` / ``headers``).
     fn set_middleware(&self, handler: Option<Py<PyAny>>) -> PyResult<()> {
-        let mut st = self.state.lock();
+        let mut st = self.state.write();
         st.middleware = handler;
         Ok(())
     }
@@ -320,7 +321,7 @@ impl App {
     }
 
     fn openapi_json(&self) -> PyResult<String> {
-        let st = self.state.lock();
+        let st = self.state.read();
         let oa = st.openapi.lock();
         Ok(oa.to_string())
     }


### PR DESCRIPTION
Closes #4

- `App` state: `Arc<Mutex<AppState>>` → `Arc<RwLock<AppState>>` (parking_lot).
- `run_rsgi` and all read-only `lib.rs` paths use `read()`; `add_route`, `freeze`, `set_openapi_served`, `set_middleware` use `write()`. `set_openapi_title` only mutates the inner OpenAPI `Mutex` → `read()` on the outer lock.
- Per-method `matchit` `Mutex`es in `AppState` unchanged.

`cargo clippy -- -D warnings` and full `pytest` pass.