### PR TITLE
feat: body_schema for OpenAPI request body without Pydantic (issue #9)

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -26,7 +26,10 @@ Served vs built: one flag, two ways to set it.
 
 Per route, the code records path, method, a short `summary` / `operationId` derived from the **handler’s** `__name__`, and a simple `200` response placeholder.
 
-For **`POST`**, **`PUT`**, and **`PATCH`**, you can pass **`body_model=...`** where the value is a **Pydantic v2** `BaseModel` class. OxyRoute calls **`model_json_schema()`** at registration time and stores that JSON Schema under the operation’s **`requestBody` → `content` → `application/json` → `schema`**. Pydantic is optional at runtime: only needed if you use `body_model`. The schema is a plain JSON value in the OpenAPI file (`$defs` and refs may appear as Pydantic emits them).
+For **`POST`**, **`PUT`**, and **`PATCH`**, you can document the JSON request body in OpenAPI in two ways (pass **at most one**):
+
+- **`body_model=...`**: a **Pydantic v2** `BaseModel` class. OxyRoute calls **`model_json_schema()`** at registration time and stores the result under **`requestBody` → `content` → `application/json` → `schema`**. Pydantic is optional at runtime: only needed if you use `body_model` (`$defs` / `$ref` appear as Pydantic emits them).
+- **`body_schema=...`**: a plain **JSON Schema** object (`dict` / mapping), e.g. from hand-written spec or another library. It is **JSON-serialized** at registration time and used the same way in OpenAPI. No Pydantic import required.
 
 ## See also
 

--- a/oxyroute/app.py
+++ b/oxyroute/app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, TypeVar
 
 from . import _oxyroute
@@ -101,6 +101,7 @@ class App:
         jwt_leeway: int | None = None,
         jwt_cookie: str | None = None,
         body_model: Any | None = None,
+        body_schema: Mapping[str, Any] | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -116,6 +117,7 @@ class App:
             jwt_leeway=jwt_leeway,
             jwt_cookie=jwt_cookie,
             body_model=body_model,
+            body_schema=body_schema,
         )
 
     def put(
@@ -130,6 +132,7 @@ class App:
         jwt_leeway: int | None = None,
         jwt_cookie: str | None = None,
         body_model: Any | None = None,
+        body_schema: Mapping[str, Any] | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -145,6 +148,7 @@ class App:
             jwt_leeway=jwt_leeway,
             jwt_cookie=jwt_cookie,
             body_model=body_model,
+            body_schema=body_schema,
         )
 
     def patch(
@@ -160,6 +164,7 @@ class App:
         jwt_leeway: int | None = None,
         jwt_cookie: str | None = None,
         body_model: Any | None = None,
+        body_schema: Mapping[str, Any] | None = None,
         dependencies: list[tuple[str, Dep]] | None = None,
     ) -> Callable[[F], F]:
         return self._route(
@@ -175,6 +180,7 @@ class App:
             jwt_leeway=jwt_leeway,
             jwt_cookie=jwt_cookie,
             body_model=body_model,
+            body_schema=body_schema,
         )
 
     def delete(
@@ -246,13 +252,18 @@ class App:
         jwt_leeway: int | None = None,
         jwt_cookie: str | None = None,
         body_model: Any | None = None,
+        body_schema: Mapping[str, Any] | None = None,
     ) -> Callable[[F], F]:
         dlist = _norm_dependencies(dependencies)
 
         def wrap(handler: F) -> F:
+            if body_model is not None and body_schema is not None:
+                raise TypeError("use only one of body_model and body_schema")
             body_schema_json: str | None = None
             if body_model is not None:
                 body_schema_json = json.dumps(body_model.model_json_schema())
+            elif body_schema is not None:
+                body_schema_json = json.dumps(body_schema)
             self._app.add_route(
                 method,
                 path,

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -110,3 +110,39 @@ def test_openapi_post_request_body_from_pydantic() -> None:
     assert ct["type"] == "object"
     assert "title" in ct.get("properties", {})
     assert "count" in ct.get("properties", {})
+
+
+def test_openapi_post_request_body_from_body_schema_dict() -> None:
+    app = App()
+    raw_schema = {
+        "type": "object",
+        "required": ["a"],
+        "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+    }
+
+    @app.post("/raw", body_schema=raw_schema)
+    def create_raw(json: dict) -> str:
+        return "ok"
+
+    doc = json.loads(app.openapi_json())
+    rb = doc["paths"]["/raw"]["post"]["requestBody"]
+    assert rb["required"] is True
+    s = rb["content"]["application/json"]["schema"]
+    assert s["type"] == "object"
+    assert s["required"] == ["a"]
+    assert s["properties"]["a"]["type"] == "string"
+
+
+def test_openapi_body_model_and_body_schema_rejected() -> None:
+    pydantic = pytest.importorskip("pydantic")
+
+    class M(pydantic.BaseModel):
+        x: int
+
+    app = App()
+
+    with pytest.raises(TypeError, match="body_model and body_schema"):
+
+        @app.post("/x", body_model=M, body_schema={"type": "object"})
+        def _bad(json: dict) -> str:
+            return "n"


### PR DESCRIPTION
Closes #9

- `@app.post` / `put` / `patch`: optional `body_schema: Mapping[str, Any]` (JSON Schema dict) for `requestBody`; mutually exclusive with `body_model` (`TypeError` if both).
- `docs/openapi.md` updated.
- Tests: raw dict schema in OpenAPI, rejection of `body_model` + `body_schema` together.