### PR TITLE
fix(asgi): run handle_rsgi in executor to avoid run_coroutine_threads…

### DIFF
--- a/docs/asgi.md
+++ b/docs/asgi.md
@@ -8,9 +8,11 @@ The module `oxyroute.asgi` builds a minimal RSGI-shaped `scope` / `protocol` and
 
 ## How responses get back to ASGI
 
-The RSGI response helpers on the protocol object are **synchronous** from the Rust side. The ASGI implementation schedules `send` coroutines on the **current asyncio event loop** that was running when the request was accepted (`asyncio.run_coroutine_threadsafe` + `result()`), so the event loop in the process must be free to make progress when native code issues responses.
+The RSGI response helpers on the protocol object are **synchronous** from the Rust side. The ASGI implementation schedules `send` coroutines on the **ASGI process’s** event loop: that loop is captured in the protocol and native code uses `asyncio.run_coroutine_threadsafe` + `result()` to run each `send` on it.
 
-**Implications:** This bridge is a **practical adapter**, not a full reimplementation of RSGI under every ASGI host. Prefer **RSGI/Granian** for production with OxyRoute if you can.
+**Why the bridge does not `await` on that loop directly:** Awaiting the native `handle_rsgi` coroutine on the same loop that must drain `run_coroutine_threadsafe` can **deadlock** (the loop is blocked in `await` and never runs the scheduled `send` tasks). The bridge therefore runs `handle_rsgi` in a **thread-pool** worker using `asyncio.run()` on a **separate** event loop, while the protocol still targets the main ASGI loop for `send` scheduling.
+
+**Implications:** This bridge is a **practical adapter**, not a full reimplementation of RSGI under every ASGI host. Prefer **RSGI/Granian** for production with OxyRoute if you can. With **Uvicorn**, use a **single worker** process unless you are sure the combination is safe in your app (the usual `workers=N` + in-process `asyncio` footguns can still apply to third-party `asyncio` use).
 
 ## Limitations (current)
 
@@ -20,7 +22,7 @@ The RSGI response helpers on the protocol object are **synchronous** from the Ru
 
 ## Local testing
 
-The **httpx** project’s `ASGITransport` is used in `tests/test_asgi.py` to exercise the bridge without a real TCP server. That test is a good template for a smoke check.
+The **httpx** project’s `ASGITransport` is used in `tests/test_asgi.py` to exercise the bridge without a real TCP server. `tests/test_asgi_stress.py` runs **50** concurrent `GET` requests to guard against cross-thread/loop deadlocks in the bridge.
 
 ## See also
 

--- a/oxyroute/asgi.py
+++ b/oxyroute/asgi.py
@@ -12,6 +12,28 @@ from collections.abc import Callable
 from typing import Any
 
 
+def _run_handle_rsgi_blocking(
+    app_rsgi: Callable[[Any, Any], Any],
+    rscope: Any,
+    proto: Any,
+) -> None:
+    """Run ``handle_rsgi`` to completion on a **fresh** event loop in the thread pool.
+
+    The ASGI server's main loop must **not** ``await`` the native coroutine directly: the
+    Rust/Tokio side calls synchronous ``protocol.response_*`` which use
+    ``run_coroutine_threadsafe(..., self._loop).result()`` targeting the **main** loop.
+    If the main loop is blocked in ``await handle_rsgi``, it can never run those ``send``
+    coroutines — a classic deadlock. Running the await in ``run_in_executor`` + ``asyncio.run``
+    keeps the main loop free to drain the threadsafe queue.
+    """
+
+    async def _inner() -> None:
+        c = app_rsgi(rscope, proto)
+        await c
+
+    asyncio.run(_inner())
+
+
 def _hdr_from_asgi(raw: list[tuple[bytes, bytes]]) -> _HeaderView:
     d: dict[str, str] = {}
     for k, v in raw:
@@ -204,7 +226,13 @@ async def asgi_to_rsgi(
     )
     loop = asyncio.get_running_loop()
     proto = _RsgiProtocol(body, send, loop)
-    await app_rsgi(rscope, proto)
+    await loop.run_in_executor(
+        None,
+        _run_handle_rsgi_blocking,
+        app_rsgi,
+        rscope,
+        proto,
+    )
 
 
 def build_asgi_caller(framework_app: Any) -> Callable[..., Any]:

--- a/tests/test_asgi_stress.py
+++ b/tests/test_asgi_stress.py
@@ -1,0 +1,29 @@
+"""Concurrent ASGI requests (issue #17) — no deadlock on many parallel clients."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+from oxyroute import App
+
+
+def test_asgi_50_concurrent_gets() -> None:
+    async def _run() -> None:
+        app = App()
+
+        @app.get("/c")
+        def c() -> str:
+            return "ok"
+
+        async def one(client: httpx.AsyncClient) -> int:
+            r = await client.get("/c")
+            return r.status_code
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            tasks = [one(client) for _ in range(50)]
+            codes = await asyncio.gather(*tasks)
+        assert all(c == 200 for c in codes)
+
+    asyncio.run(_run())


### PR DESCRIPTION
…afe deadlock

- Run handle_rsgi via run_in_executor + asyncio.run on a worker loop; main ASGI loop remains free to drain run_coroutine_threadsafe from the RSGI protocol.
- Add 50-concurrent-GET stress test (httpx ASGITransport).
- Document bridge behavior and uvicorn single-worker note in docs/asgi.md.

Closes #17

## Summary

- What this PR does (1–3 sentences).
- If it closes a ticket: `Closes #N` (replace N).

## Base branch

- [x] This PR targets **`dev`**, not `main` (unless maintainers asked for a hotfix).

## Checklist

- [x] `cargo build` (and `cargo clippy` if you touched Rust)
- [x] `maturin develop` + tests as in [docs/development.md](docs/development.md) (e.g. pytest from a clean cwd / installed wheel)
- [x] No unrelated drive-by refactors; commits are [atomic and scoped](https://github.com/QueryaHub/OxyRoute/blob/main/docs/development-workflow.md)

## Note on `.github/ISSUE_BACKLOG/`

If you only touch issue template files under [`.github/ISSUE_BACKLOG/`](.github/ISSUE_BACKLOG/) (not application code), say so in the summary. Prefer a **separate** PR for backlog-only edits when possible.
