### PR TITLE
security(headers): validate response header/cookie values against CRLF

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -44,6 +44,14 @@ fn oxyroute_debug() -> bool {
         .unwrap_or(false)
 }
 
+fn contains_crlf(s: &str) -> bool {
+    s.contains('\r') || s.contains('\n')
+}
+
+fn is_unsafe_cookie_line(s: &str) -> bool {
+    s.chars().any(|c| c == '\r' || c == '\n' || c.is_control())
+}
+
 /// Map Python `PyErr` to HTTP 500 with a JSON body (no exception text unless `OXYROUTE_DEBUG=1`).
 async fn send_internal_error(
     protocol: &Py<PyAny>,
@@ -98,6 +106,9 @@ async fn try_http_exception(protocol: &Py<PyAny>, err: &PyErr) -> PyResult<Optio
                 let pair = item.downcast::<PyTuple>()?;
                 let k: String = pair.get_item(0)?.extract()?;
                 let v: String = pair.get_item(1)?.extract()?;
+                if contains_crlf(&k) || contains_crlf(&v) {
+                    return Ok(None);
+                }
                 headers.push((k, v));
             }
             Ok(Some((status, body, headers)))
@@ -994,6 +1005,11 @@ fn structured_from_status_body(
             for (k, v) in d.iter() {
                 let key: String = k.extract()?;
                 let val: String = v.extract()?;
+                if contains_crlf(&key) || contains_crlf(&val) {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "unsafe response header contains CR or LF",
+                    ));
+                }
                 if key.eq_ignore_ascii_case("content-type") {
                     has_ct = true;
                 }
@@ -1008,6 +1024,11 @@ fn structured_from_status_body(
         if !c.is_none() {
             for item in c.downcast::<PyList>()?.iter() {
                 let s: String = item.extract()?;
+                if is_unsafe_cookie_line(&s) {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "unsafe set-cookie value contains control characters",
+                    ));
+                }
                 pairs.push(("set-cookie".to_string(), s));
             }
         }

--- a/tests/test_header_sanitization.py
+++ b/tests/test_header_sanitization.py
@@ -1,0 +1,61 @@
+"""Issue #72: reject unsafe CR/LF control chars in response headers/cookies."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+from oxyroute import App, HTTPException, Response
+
+
+def test_response_header_crlf_is_rejected_with_500() -> None:
+    app = App()
+
+    @app.get("/h")
+    def h() -> Response:
+        return Response(status=200, body="ok", headers={"X-Bad\r\nInjected": "1"})
+
+    async def _run() -> None:
+        tr = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=tr, base_url="http://test") as c:
+            r = await c.get("/h")
+        assert r.status_code == 500
+        assert r.headers.get("x-bad") is None
+        assert r.json().get("error") == "internal server error"
+
+    asyncio.run(_run())
+
+
+def test_response_cookie_control_chars_is_rejected_with_500() -> None:
+    app = App()
+
+    @app.get("/c")
+    def c() -> Response:
+        return Response(status=200, body="ok", cookies=["a=1\r\nX: y"])
+
+    async def _run() -> None:
+        tr = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=tr, base_url="http://test") as c:
+            r = await c.get("/c")
+        assert r.status_code == 500
+        assert r.json().get("error") == "internal server error"
+
+    asyncio.run(_run())
+
+
+def test_http_exception_header_crlf_is_safely_downgraded_to_500() -> None:
+    app = App()
+
+    @app.get("/e")
+    def e() -> str:
+        raise HTTPException(400, "bad", headers={"X-Err\nInject": "1"})
+
+    async def _run() -> None:
+        tr = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=tr, base_url="http://test") as c:
+            r = await c.get("/e")
+        assert r.status_code == 500
+        assert r.headers.get("x-err") is None
+        assert r.json().get("error") == "internal server error"
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add framework-side sanitization that rejects response header names/values containing CR/LF
- reject unsafe Set-Cookie lines containing control characters instead of forwarding them downstream
- add regression tests for malicious Response/HTTPException header and cookie payloads

## Test plan
- [x] `uv run maturin develop --uv`
- [x] `uv run pytest tests/test_header_sanitization.py tests/test_http_exception.py tests/test_asgi.py`

Closes #72