### PR TITLE
perf(asgi): remove per-request fresh event-loop creation

### DIFF
--- a/oxyroute/asgi.py
+++ b/oxyroute/asgi.py
@@ -9,8 +9,20 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from collections.abc import Callable
 from typing import Any
+
+_BLOCKING_LOOP_LOCAL = threading.local()
+
+
+def _close_blocking_loop_for_current_thread() -> None:
+    loop = getattr(_BLOCKING_LOOP_LOCAL, "loop", None)
+    if loop is None:
+        return
+    if not loop.is_closed():
+        loop.close()
+    _BLOCKING_LOOP_LOCAL.loop = None
 
 
 class WebSocket:
@@ -80,21 +92,27 @@ def _run_handle_rsgi_blocking(
     rscope: Any,
     proto: Any,
 ) -> None:
-    """Run ``handle_rsgi`` to completion on a **fresh** event loop in the thread pool.
+    """Run ``handle_rsgi`` to completion on a thread-local event loop.
 
-    The ASGI server's main loop must **not** ``await`` the native coroutine directly: the
-    Rust/Tokio side calls synchronous ``protocol.response_*`` while this coroutine runs on a
-    worker thread. Those response calls enqueue ASGI messages onto the **main** loop, where a
-    dedicated drain task performs ``send(...)`` in order. Running this await in
-    ``run_in_executor`` + ``asyncio.run`` keeps the main loop free for queue draining and avoids
-    deadlock-prone cross-thread blocking waits.
+    The ASGI server's main loop must **not** ``await`` the native coroutine directly: the Rust
+    side calls synchronous ``protocol.response_*`` while this coroutine runs on a worker thread.
+    Response calls enqueue ASGI messages onto the main loop, where a dedicated drain task performs
+    ``send(...)`` in order.
+
+    For performance, each worker thread lazily creates and then reuses one event loop instead of
+    allocating a fresh loop per request.
     """
 
     async def _inner() -> None:
         c = app_rsgi(rscope, proto)
         await c
 
-    asyncio.run(_inner())
+    loop = getattr(_BLOCKING_LOOP_LOCAL, "loop", None)
+    if loop is None or loop.is_closed():
+        loop = asyncio.new_event_loop()
+        _BLOCKING_LOOP_LOCAL.loop = loop
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(_inner())
 
 
 def _hdr_from_asgi(raw: list[tuple[bytes, bytes]]) -> _HeaderView:

--- a/tests/test_asgi_internals.py
+++ b/tests/test_asgi_internals.py
@@ -216,3 +216,19 @@ def test_build_asgi_caller_uses_inner_app_when_handle_rsgi_missing() -> None:
     }
     asyncio.run(app(scope, receive, send))
     assert called == ["inner"]
+
+
+def test_run_handle_rsgi_blocking_does_not_use_asyncio_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("asyncio.run must not be used in blocking bridge path")
+
+    monkeypatch.setattr(asgi_mod.asyncio, "run", _boom)
+
+    async def _coro(_scope: object, _proto: object) -> None:
+        return None
+
+    try:
+        asgi_mod._run_handle_rsgi_blocking(_coro, object(), object())
+        asgi_mod._run_handle_rsgi_blocking(_coro, object(), object())
+    finally:
+        asgi_mod._close_blocking_loop_for_current_thread()


### PR DESCRIPTION
## Summary
- replace per-request `asyncio.run` in the ASGI blocking bridge with a reused thread-local event loop
- preserve request behavior while reducing fixed bridge overhead and executor churn
- add regression test that fails if `asyncio.run` is used again on the blocking path

## Test plan
- [x] `uv run pytest tests/test_asgi_internals.py tests/test_asgi_stress.py tests/test_asgi.py`

## Benchmark notes
- before: one fresh event loop allocation per request in `_run_handle_rsgi_blocking`
- after: lazy single loop allocation per worker thread, reused across requests

Closes #73