### PR TITLE
feat(websocket): native RSGI WebSocket support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.0] - unreleased
 
+### Added
+
+- Native RSGI WebSocket support: `@app.websocket(path)` and `oxyroute.WebSocket` are
+  exported from the package and dispatched directly inside the Rust extension. No ASGI
+  shim is involved; the helper class wraps Granian's `RSGIWebsocketProtocol` and exposes
+  `accept`, `receive` / `receive_text` / `receive_bytes`, `send_text` / `send_bytes` /
+  `send_json`, and `close`. Path matching uses the same `matchit` syntax as HTTP routes
+  and lives in its own router. Unknown paths produce a polite `close(1000)`; handler
+  errors trigger `close(1011)`.
+
 ### Removed (breaking)
 
 - The optional ASGI 3.0 compatibility bridge (`oxyroute.asgi`) was removed. `App` is no
@@ -15,7 +25,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ``granian --interface rsgi``.
 - The ASGI-based `@app.websocket(path)` decorator and the
   `App._handle_asgi_websocket` plumbing were removed alongside the bridge. Native RSGI
-  WebSocket support will be reintroduced in a follow-up release.
+  WebSocket support is reintroduced in this release (see *Added*).
 
 ### Migration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ Granian still invokes a Python `App` object; the “win” is doing routing, bod
 | [CSRF](csrf.md) | Double-submit, `apply_csrf`, `csrf_layer` + CORS |
 | [JWT](jwt.md) | `require_jwt`, HS* / RSA / EC PEM, `decode_jwt_hs` (HS* tests) |
 | [SSE](sse.md) | `send_sse`, event framing, streaming caveats |
+| [WebSockets](websocket.md) | Native RSGI `@app.websocket(path)` and `oxyroute.WebSocket` |
 | [HTTP/2 with Granian](http2.md) | Transport guarantees vs server/proxy responsibilities |
 | [Dependencies](dependencies.md) | `Depends`, `dependencies=[...]`, `freeze` |
 | [OpenAPI](openapi.md) | `openapi.json` route, title, `openapi_json()` |

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -1,0 +1,100 @@
+# WebSockets (native RSGI)
+
+OxyRoute v0.3.0 ships a **native RSGI WebSocket** binding — the Granian
+[`RSGIWebsocketProtocol`](https://github.com/emmett-framework/granian/blob/master/granian/rsgi.py)
+is matched and dispatched directly inside the Rust `_oxyroute` extension. There is no ASGI
+bridge: the legacy `--interface asgi` WebSocket path was removed alongside the rest of the
+ASGI shim.
+
+## Quick start
+
+```python
+from oxyroute import App, WebSocket
+
+app = App()
+
+
+@app.websocket("/ws/:room")
+async def chat(ws: WebSocket) -> None:
+    await ws.accept()
+    room = ws.path_params["room"]
+    await ws.send_text(f"hello, {room}")
+    while True:
+        msg = await ws.receive_text()
+        if msg == "bye":
+            break
+        await ws.send_text(f"echo:{msg}")
+    await ws.close()
+```
+
+Run it like any other OxyRoute app:
+
+```bash
+granian app:app --interface rsgi --host 127.0.0.1 --port 8000
+```
+
+## API
+
+`oxyroute.WebSocket` is a thin Rust pyclass exported by the native module.
+
+| Member | Kind | Description |
+|---|---|---|
+| `scope` | property | The Granian RSGI scope (`proto == "websocket"`). |
+| `path_params` | property | `dict[str, str]` of path parameters extracted by the router. |
+| `is_closed` | property | `True` once `close()` has run or the peer disconnected. |
+| `await ws.accept()` | coroutine | Performs the handshake; required before send/receive. |
+| `await ws.receive()` | coroutine | Returns the next frame as `str` **or** `bytes`. Raises `RuntimeError` if the peer closed. |
+| `await ws.receive_text()` | coroutine | Like `receive`, but raises `ValueError` on a binary frame. |
+| `await ws.receive_bytes()` | coroutine | Like `receive`, but raises `ValueError` on a text frame. |
+| `await ws.send_text(s)` | coroutine | Send a text frame. |
+| `await ws.send_bytes(b)` | coroutine | Send a binary frame. |
+| `await ws.send_json(obj)` | coroutine | `json.dumps(obj)` then `send_text`. |
+| `await ws.close(code=None)` | coroutine | Close the connection (defaults to 1000). Idempotent. |
+
+Sync handlers are accepted by `@app.websocket(path)` for symmetry but should generally be
+async — Granian dispatches WebSockets on its event loop and most useful patterns require
+`await`.
+
+## Routing semantics
+
+* WebSocket routes live in their own `matchit::Router`. They never collide with HTTP routes,
+  so `GET /ws/:room` and `WS /ws/:room` can coexist.
+* Path syntax mirrors HTTP routes: `/ws/:room`, `/ws/:room/*rest`. Captured params are
+  available via `ws.path_params`.
+* Unknown WebSocket paths trigger a polite `protocol.close(1000)` (no 404 — close codes are
+  the WebSocket equivalent).
+* Calling `app.freeze()` locks WebSocket route registration the same way it locks HTTP
+  routes; further `@app.websocket(...)` raises `ValueError`.
+
+## Error handling
+
+* If the handler raises before completing, OxyRoute logs the error and calls
+  `protocol.close(1011)` (server-side error). The peer sees a clean close, never an open
+  connection that hangs.
+* If the **peer** closes (Granian sends `WebsocketMessageType.close`, kind `0`), the next
+  `receive*` raises `RuntimeError("WebSocket closed by peer")` and `ws.is_closed` becomes
+  `True`. A subsequent `await ws.close()` is a no-op (no double close).
+
+## Testing
+
+Drive the dispatcher in-process with mocked Granian-style scope/protocol/transport
+objects — see [`tests/test_websocket_native.py`](../tests/test_websocket_native.py) for a
+worked example. The pattern:
+
+1. Build an `_WSScope` dataclass with `proto = "websocket"`, the request `path`, etc.
+2. Build a mock `protocol` with an `async accept()` returning a transport, a
+   `close(status)` setter, and the transport's `async receive() / send_str / send_bytes`.
+3. Run `await app.handle_rsgi(scope, protocol)` from inside `asyncio.run(...)`.
+
+For end-to-end coverage with a real Granian server use a subprocess test similar to
+[`tests/test_granian_e2e.py`](../tests/test_granian_e2e.py), connecting with a real
+WebSocket client (e.g. `websockets`).
+
+## Migration from the previous ASGI WebSocket spike
+
+The pre-v0.3.0 ASGI WebSocket helper was removed. If you were using it:
+
+* Replace `from oxyroute.asgi import WebSocket` with `from oxyroute import WebSocket`.
+* Drop any `--interface asgi` Granian command lines — OxyRoute is RSGI-only.
+* `await ws.accept(subprotocol="…")` no longer accepts subprotocols (Granian's RSGI
+  WebSocket handshake selects them via headers; document that explicitly if you need it).

--- a/oxyroute/__init__.py
+++ b/oxyroute/__init__.py
@@ -1,6 +1,6 @@
 # Native extension first — prevents circular import with `app` importing `_oxyroute`.
 import oxyroute._oxyroute  # noqa: F401
-from oxyroute._oxyroute import decode_jwt_hs
+from oxyroute._oxyroute import WebSocket, decode_jwt_hs
 from oxyroute.app import App, Depends
 from oxyroute.cors import CORSConfig, apply_cors
 from oxyroute.csrf import CSRFConfig, apply_csrf, csrf_layer
@@ -20,6 +20,7 @@ __all__ = [
     "Response",
     "SSEEvent",
     "SecurityHeadersConfig",
+    "WebSocket",
     "__version__",
     "apply_cors",
     "apply_csrf",

--- a/oxyroute/app.py
+++ b/oxyroute/app.py
@@ -268,6 +268,24 @@ class App:
             jwt_cookie=jwt_cookie,
         )
 
+    def websocket(self, path: str) -> Callable[[F], F]:
+        """
+        Register a native RSGI WebSocket handler.
+
+        ``path`` uses the same ``matchit`` syntax as HTTP routes (e.g. ``/ws/:room``).
+        The handler receives a single :class:`oxyroute.WebSocket` argument; ``await``
+        :meth:`oxyroute.WebSocket.accept` once before sending or receiving frames.
+
+        Sync handlers run inline (the Rust dispatcher does not bridge them through Tokio
+        twice); async handlers are awaited on Granian's loop.
+        """
+
+        def wrap(handler: F) -> F:
+            self._app.add_websocket_route(path, handler)
+            return handler
+
+        return wrap
+
     def options(
         self,
         path: str,

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -13,8 +13,9 @@ use crate::form::{self, ParsedFile};
 use crate::params::{build_request_context, header_get_lax, parse_query, value_for_path_param};
 use crate::response;
 use crate::schema::json_to_py;
-use crate::state::{match_route, methods_matching_path, AppState};
+use crate::state::{match_route, match_ws_route, methods_matching_path, AppState};
 use crate::token::{build_decoding_key, extract_bearer, extract_cookie_value};
+use crate::websocket::WebSocket;
 
 type HttpExceptionPayload = (u16, Vec<u8>, Vec<(String, String)>);
 
@@ -158,6 +159,9 @@ pub async fn run_rsgi(
     protocol: Py<PyAny>,
 ) -> PyResult<PyObject> {
     let proto: String = Python::with_gil(|py| scope.bind(py).getattr("proto")?.extract())?;
+    if proto == "websocket" {
+        return run_rsgi_websocket(state, scope, protocol).await;
+    }
     if proto != "http" {
         return Ok(Python::with_gil(|py| py.None()));
     }
@@ -1075,4 +1079,79 @@ fn value_to_bytes_and_ct(py: Python<'_>, b: &Bound<'_, PyAny>) -> PyResult<(Vec<
         s.into_bytes(),
         "application/json; charset=utf-8".to_string(),
     ))
+}
+
+/// Dispatch a Granian RSGI WebSocket scope: match `path` in `AppState::websocket` and run
+/// the handler with a [`WebSocket`] helper. No matching route → ``protocol.close(1000)``;
+/// handler error → close (best-effort) and propagate to logs.
+async fn run_rsgi_websocket(
+    state: Arc<RwLock<AppState>>,
+    scope: Py<PyAny>,
+    protocol: Py<PyAny>,
+) -> PyResult<PyObject> {
+    let path: String =
+        Python::with_gil(|py| -> PyResult<String> { scope.bind(py).getattr("path")?.extract() })?;
+    ensure_compiled_snapshot(&state);
+    let route_match = {
+        let st = state.read();
+        match_ws_route(&st, &path)
+    };
+    let Some((route_idx, param_map)) = route_match else {
+        // No route → polite close. ``close`` is sync on RSGIWebsocketProtocol.
+        let _ = Python::with_gil(|py| -> PyResult<()> {
+            let p = protocol.bind(py);
+            let _ = p.call_method1("close", (1000i32,));
+            Ok(())
+        });
+        return Ok(Python::with_gil(|py| py.None()));
+    };
+    let (handler, is_async) = Python::with_gil(|_py| -> PyResult<(Py<PyAny>, bool)> {
+        let st = state.read();
+        let e = st
+            .websocket_routes
+            .get(route_idx)
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("ws route index"))?;
+        Ok((e.handler.clone(), e.is_async))
+    })?;
+    let call_result = Python::with_gil(|py| -> PyResult<(PyObject, bool)> {
+        let ws = WebSocket::new(protocol.clone_ref(py), scope.clone_ref(py), param_map);
+        let py_ws = Py::new(py, ws)?;
+        let res = handler.bind(py).call1((py_ws,))?.unbind();
+        Ok((res, is_async))
+    });
+    let (res, run_async) = match call_result {
+        Ok(x) => x,
+        Err(e) => {
+            log::error!(target: "oxyroute", "websocket {path} handler raised before await: {e}");
+            let _ = Python::with_gil(|py| -> PyResult<()> {
+                let _ = protocol.bind(py).call_method1("close", (1011i32,));
+                Ok(())
+            });
+            return Ok(Python::with_gil(|py| py.None()));
+        }
+    };
+    if run_async {
+        let fut = match Python::with_gil(|py| {
+            let b = res.bind(py).clone();
+            pyo3_async_runtimes::tokio::into_future(b)
+        }) {
+            Ok(f) => f,
+            Err(e) => {
+                log::error!(target: "oxyroute", "websocket {path} bridge: {e}");
+                let _ = Python::with_gil(|py| -> PyResult<()> {
+                    let _ = protocol.bind(py).call_method1("close", (1011i32,));
+                    Ok(())
+                });
+                return Ok(Python::with_gil(|py| py.None()));
+            }
+        };
+        if let Err(e) = fut.await {
+            log::error!(target: "oxyroute", "websocket {path} handler error: {e}");
+            let _ = Python::with_gil(|py| -> PyResult<()> {
+                let _ = protocol.bind(py).call_method1("close", (1011i32,));
+                Ok(())
+            });
+        }
+    }
+    Ok(Python::with_gil(|py| py.None()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod response;
 mod schema;
 mod state;
 mod token;
+mod websocket;
 
 use dispatch::run_rsgi;
 use state::AppState;
@@ -282,6 +283,39 @@ impl App {
         Ok(())
     }
 
+    /// Register a WebSocket route. ``handler`` receives a single
+    /// :class:`oxyroute._oxyroute.WebSocket` argument; sync handlers run inline, async
+    /// handlers are awaited on Granian's loop. Same matchit ``/ws/:room`` syntax as HTTP routes.
+    fn add_websocket_route(
+        &self,
+        py: Python<'_>,
+        path: String,
+        handler: Py<PyAny>,
+    ) -> PyResult<()> {
+        {
+            let st = self.state.read();
+            if st.frozen {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "app is frozen; no more add_websocket_route",
+                ));
+            }
+        }
+        let inspect = py.import("inspect")?;
+        let f = inspect.getattr("iscoroutinefunction")?;
+        let is_async: bool = f.call1((handler.clone_ref(py),))?.extract()?;
+        let mut st = self.state.write();
+        let idx = st.websocket_routes.len();
+        st.websocket_routes
+            .push(state::WebsocketRoute { handler, is_async });
+        {
+            let mut m = st.websocket.lock();
+            m.insert(&path, idx)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{e}")))?;
+        }
+        st.compiled = None;
+        Ok(())
+    }
+
     /// Lock route registration. Linear dependency list is a valid topological order (DAG of independent roots).
     fn freeze(&self) -> PyResult<()> {
         let mut st = self.state.write();
@@ -378,6 +412,7 @@ impl PyDepends {
 fn _oxyroute(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<App>()?;
     m.add_class::<PyDepends>()?;
+    m.add_class::<websocket::WebSocket>()?;
     m.add_function(wrap_pyfunction!(token::decode_jwt_hs, m)?)?;
     Ok(())
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,6 +14,7 @@ pub struct CompiledRouters {
     pub patch: Router<usize>,
     pub delete: Router<usize>,
     pub options: Router<usize>,
+    pub websocket: Router<usize>,
 }
 
 fn router_for_compiled<'a>(c: &'a CompiledRouters, method: &str) -> Option<&'a Router<usize>> {
@@ -26,6 +27,12 @@ fn router_for_compiled<'a>(c: &'a CompiledRouters, method: &str) -> Option<&'a R
         "OPTIONS" => Some(&c.options),
         _ => None,
     }
+}
+
+/// One WebSocket route: just a handler + async flag (no JWT / deps / body).
+pub struct WebsocketRoute {
+    pub handler: Py<PyAny>,
+    pub is_async: bool,
 }
 
 pub struct RouteEntry {
@@ -60,12 +67,14 @@ pub struct RouteEntry {
 
 pub struct AppState {
     pub routes: Vec<RouteEntry>,
+    pub websocket_routes: Vec<WebsocketRoute>,
     pub get: Mutex<Router<usize>>,
     pub post: Mutex<Router<usize>>,
     pub put: Mutex<Router<usize>>,
     pub patch: Mutex<Router<usize>>,
     pub delete: Mutex<Router<usize>>,
     pub options: Mutex<Router<usize>>,
+    pub websocket: Mutex<Router<usize>>,
     pub openapi: Mutex<serde_json::Value>,
     /// When `Some`, route matching uses these tables without taking per-router mutexes
     /// (populated in [`App::freeze`](crate::App::freeze)).
@@ -92,12 +101,14 @@ impl AppState {
         });
         Self {
             routes: Vec::new(),
+            websocket_routes: Vec::new(),
             get: Mutex::new(Router::new()),
             post: Mutex::new(Router::new()),
             put: Mutex::new(Router::new()),
             patch: Mutex::new(Router::new()),
             delete: Mutex::new(Router::new()),
             options: Mutex::new(Router::new()),
+            websocket: Mutex::new(Router::new()),
             openapi: Mutex::new(openapi),
             compiled: None,
             frozen: false,
@@ -117,8 +128,30 @@ impl AppState {
             patch: self.patch.lock().clone(),
             delete: self.delete.lock().clone(),
             options: self.options.lock().clone(),
+            websocket: self.websocket.lock().clone(),
         }
     }
+}
+
+/// Lookup a WebSocket route by path (uses compiled snapshot when available).
+pub fn match_ws_route(state: &AppState, path: &str) -> Option<(usize, HashMap<String, String>)> {
+    if let Some(c) = &state.compiled {
+        return c.websocket.at(path).ok().map(|m| {
+            let mut pmap = HashMap::new();
+            for (k, v) in m.params.iter() {
+                pmap.insert(k.to_string(), v.to_string());
+            }
+            (*m.value, pmap)
+        });
+    }
+    let g = state.websocket.lock();
+    g.at(path).ok().map(|m| {
+        let mut pmap = HashMap::new();
+        for (k, v) in m.params.iter() {
+            pmap.insert(k.to_string(), v.to_string());
+        }
+        (*m.value, pmap)
+    })
 }
 
 pub fn map_method_router<'a>(

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -211,11 +211,7 @@ impl WebSocket {
     }
 
     /// Send a JSON-serialised object as a text frame (uses :func:`json.dumps`).
-    fn send_json<'py>(
-        &self,
-        py: Python<'py>,
-        data: Py<PyAny>,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn send_json<'py>(&self, py: Python<'py>, data: Py<PyAny>) -> PyResult<Bound<'py, PyAny>> {
         let transport = self.transport_clone(py)?;
         let json_mod = py.import("json")?;
         let dumped = json_mod.call_method1("dumps", (data.bind(py),))?;
@@ -230,25 +226,31 @@ impl WebSocket {
         })
     }
 
-    /// Close the connection. ``code`` defaults to 1000 (normal closure). Idempotent.
+    /// Close the connection. ``code`` defaults to 1000 (normal closure).
+    ///
+    /// Returns an awaitable that completes immediately so handlers can use
+    /// ``await ws.close()``. Idempotent — repeated calls are no-ops.
     #[pyo3(signature = (code=None))]
-    fn close(&self, py: Python<'_>, code: Option<i32>) -> PyResult<Py<PyAny>> {
-        {
+    fn close<'py>(&self, py: Python<'py>, code: Option<i32>) -> PyResult<Bound<'py, PyAny>> {
+        let already_closed = {
             let mut g = self.closed.lock();
-            if *g {
-                return Ok(py.None());
-            }
+            let was = *g;
             *g = true;
+            was
+        };
+        if !already_closed {
+            let st = code.unwrap_or(1000);
+            let _ = self
+                .protocol
+                .bind(py)
+                .call_method1("close", (st,))
+                .map_err(|e| {
+                    log::debug!(target: "oxyroute", "websocket close ignored: {e}");
+                    e
+                });
         }
-        let st = code.unwrap_or(1000);
-        let _ = self
-            .protocol
-            .bind(py)
-            .call_method1("close", (st,))
-            .map_err(|e| {
-                log::debug!(target: "oxyroute", "websocket close ignored: {e}");
-                e
-            });
-        Ok(py.None())
+        pyo3_async_runtimes::tokio::future_into_py(py, async {
+            Python::with_gil(|py| Ok(py.None()))
+        })
     }
 }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -1,0 +1,254 @@
+//! Native RSGI WebSocket helper exposed to Python as ``oxyroute._oxyroute.WebSocket``.
+//!
+//! The Python `@app.websocket(path)` decorator (see [oxyroute/app.py](../oxyroute/app.py))
+//! registers a coroutine handler that receives a [`WebSocket`] instance built around the
+//! underlying Granian [`RSGIWebsocketProtocol`][1]. All async methods delegate directly to
+//! the Granian protocol / transport coroutines so Python keeps awaiting the same objects
+//! it would have awaited natively — no extra Tokio future bridge, no scheduling cost.
+//!
+//! [1]: https://github.com/emmett-framework/granian — see `granian/rsgi.py`.
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyString, PyTuple};
+
+/// Thin async wrapper around a Granian RSGI WebSocket connection.
+///
+/// Lifecycle:
+///
+/// 1. ``await ws.accept()`` performs the WebSocket handshake and stores the underlying transport.
+/// 2. ``await ws.receive()`` / ``receive_text()`` / ``receive_bytes()`` to read frames.
+/// 3. ``await ws.send_text(...)`` / ``send_bytes(...)`` to write frames.
+/// 4. ``await ws.close(code=...)`` to close the connection (defaults to 1000 — normal closure).
+///
+/// All methods are awaitable and run on Granian's event loop; ``close`` is best-effort once
+/// the peer has already disconnected.
+#[pyclass(name = "WebSocket", module = "oxyroute._oxyroute")]
+pub struct WebSocket {
+    protocol: Py<PyAny>,
+    scope: Py<PyAny>,
+    transport: Arc<Mutex<Option<Py<PyAny>>>>,
+    path_params: HashMap<String, String>,
+    closed: Arc<Mutex<bool>>,
+}
+
+impl WebSocket {
+    pub fn new(
+        protocol: Py<PyAny>,
+        scope: Py<PyAny>,
+        path_params: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            protocol,
+            scope,
+            transport: Arc::new(Mutex::new(None)),
+            path_params,
+            closed: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    fn transport_clone(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let g = self.transport.lock();
+        match g.as_ref() {
+            Some(t) => Ok(t.clone_ref(py)),
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "WebSocket: call accept() before send/receive",
+            )),
+        }
+    }
+}
+
+#[pymethods]
+impl WebSocket {
+    /// The Granian RSGI scope (proto = ``"websocket"``).
+    #[getter]
+    fn scope(&self, py: Python<'_>) -> Py<PyAny> {
+        self.scope.clone_ref(py)
+    }
+
+    /// Path parameters extracted by the router (e.g. ``/ws/:room`` → ``{"room": "lobby"}``).
+    #[getter]
+    fn path_params<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new(py);
+        for (k, v) in &self.path_params {
+            d.set_item(k.as_str(), v.as_str())?;
+        }
+        Ok(d)
+    }
+
+    /// True once :meth:`close` has been called (or the peer disconnected).
+    #[getter]
+    fn is_closed(&self) -> bool {
+        *self.closed.lock()
+    }
+
+    /// Perform the handshake. Stores the transport for subsequent send/receive calls.
+    fn accept<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let proto = self.protocol.clone_ref(py);
+        let transport_slot = self.transport.clone();
+        let coro = proto.bind(py).call_method0("accept")?;
+        let fut = pyo3_async_runtimes::tokio::into_future(coro)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let result = fut.await?;
+            Python::with_gil(|py| {
+                *transport_slot.lock() = Some(result);
+                Ok(py.None())
+            })
+        })
+    }
+
+    /// Receive the next WebSocket message; returns ``str`` or ``bytes``. Raises ``RuntimeError``
+    /// if the peer has closed the connection (Granian close kind = 0).
+    fn receive<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let coro = transport.bind(py).call_method0("receive")?;
+        let fut = pyo3_async_runtimes::tokio::into_future(coro)?;
+        let closed_flag = self.closed.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let msg = fut.await?;
+            Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+                let m = msg.bind(py);
+                let kind: i64 = m.getattr("kind")?.extract()?;
+                if kind == 0 {
+                    *closed_flag.lock() = true;
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "WebSocket closed by peer",
+                    ));
+                }
+                let data = m.getattr("data")?;
+                Ok(data.unbind())
+            })
+        })
+    }
+
+    /// Receive the next message as ``str``; raises ``ValueError`` if a binary frame arrives.
+    fn receive_text<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let coro = transport.bind(py).call_method0("receive")?;
+        let fut = pyo3_async_runtimes::tokio::into_future(coro)?;
+        let closed_flag = self.closed.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let msg = fut.await?;
+            Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+                let m = msg.bind(py);
+                let kind: i64 = m.getattr("kind")?.extract()?;
+                if kind == 0 {
+                    *closed_flag.lock() = true;
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "WebSocket closed by peer",
+                    ));
+                }
+                if kind != 2 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "expected text frame",
+                    ));
+                }
+                let data = m.getattr("data")?;
+                let s = data.downcast::<PyString>()?;
+                Ok(s.clone().unbind().into())
+            })
+        })
+    }
+
+    /// Receive the next message as ``bytes``; raises ``ValueError`` if a text frame arrives.
+    fn receive_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let coro = transport.bind(py).call_method0("receive")?;
+        let fut = pyo3_async_runtimes::tokio::into_future(coro)?;
+        let closed_flag = self.closed.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let msg = fut.await?;
+            Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+                let m = msg.bind(py);
+                let kind: i64 = m.getattr("kind")?.extract()?;
+                if kind == 0 {
+                    *closed_flag.lock() = true;
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "WebSocket closed by peer",
+                    ));
+                }
+                if kind != 1 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "expected binary frame",
+                    ));
+                }
+                let data = m.getattr("data")?;
+                let b = data.downcast::<PyBytes>()?;
+                Ok(b.clone().unbind().into())
+            })
+        })
+    }
+
+    /// Send a text frame. Returns when Granian has flushed the message.
+    fn send_text<'py>(&self, py: Python<'py>, data: String) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let coro = transport
+            .bind(py)
+            .call_method1("send_str", PyTuple::new(py, [data])?)?;
+        pyo3_async_runtimes::tokio::into_future(coro).and_then(|fut| {
+            pyo3_async_runtimes::tokio::future_into_py(py, async move {
+                fut.await?;
+                Python::with_gil(|py| Ok(py.None()))
+            })
+        })
+    }
+
+    /// Send a binary frame. Returns when Granian has flushed the message.
+    fn send_bytes<'py>(&self, py: Python<'py>, data: Vec<u8>) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let pb = PyBytes::new(py, &data);
+        let coro = transport
+            .bind(py)
+            .call_method1("send_bytes", PyTuple::new(py, [pb])?)?;
+        pyo3_async_runtimes::tokio::into_future(coro).and_then(|fut| {
+            pyo3_async_runtimes::tokio::future_into_py(py, async move {
+                fut.await?;
+                Python::with_gil(|py| Ok(py.None()))
+            })
+        })
+    }
+
+    /// Send a JSON-serialised object as a text frame (uses :func:`json.dumps`).
+    fn send_json<'py>(
+        &self,
+        py: Python<'py>,
+        data: Py<PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let json_mod = py.import("json")?;
+        let dumped = json_mod.call_method1("dumps", (data.bind(py),))?;
+        let coro = transport
+            .bind(py)
+            .call_method1("send_str", PyTuple::new(py, [dumped])?)?;
+        pyo3_async_runtimes::tokio::into_future(coro).and_then(|fut| {
+            pyo3_async_runtimes::tokio::future_into_py(py, async move {
+                fut.await?;
+                Python::with_gil(|py| Ok(py.None()))
+            })
+        })
+    }
+
+    /// Close the connection. ``code`` defaults to 1000 (normal closure). Idempotent.
+    #[pyo3(signature = (code=None))]
+    fn close(&self, py: Python<'_>, code: Option<i32>) -> PyResult<Py<PyAny>> {
+        {
+            let mut g = self.closed.lock();
+            if *g {
+                return Ok(py.None());
+            }
+            *g = true;
+        }
+        let st = code.unwrap_or(1000);
+        let _ = self
+            .protocol
+            .bind(py)
+            .call_method1("close", (st,))
+            .map_err(|e| {
+                log::debug!(target: "oxyroute", "websocket close ignored: {e}");
+                e
+            });
+        Ok(py.None())
+    }
+}

--- a/tests/test_websocket_native.py
+++ b/tests/test_websocket_native.py
@@ -1,0 +1,232 @@
+"""Unit tests for the native RSGI WebSocket dispatch path (no ASGI involved).
+
+Drives :meth:`oxyroute.app.App.handle_rsgi` directly with a mocked Granian-style
+``scope`` / ``protocol`` pair (see :class:`granian.rsgi.RSGIWebsocketProtocol` /
+:class:`granian.rsgi.RSGIWebsocketTransport` for the live equivalents). The mocks
+return real ``asyncio`` coroutines so ``pyo3-async-runtimes`` can bridge them
+to Rust the same way Granian does at runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from oxyroute import App, WebSocket
+
+
+@dataclass
+class _Headers:
+    pairs: list[tuple[str, str]] = field(default_factory=list)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        for k, v in self.pairs:
+            if k.lower() == key.lower():
+                return v
+        return default
+
+
+@dataclass
+class _WSScope:
+    proto: str = "websocket"
+    path: str = "/"
+    method: str = "GET"
+    query_string: str = ""
+    http_version: str = "1.1"
+    rsgi_version: str = "1.5"
+    server: str = "127.0.0.1:8000"
+    client: str = "127.0.0.1:1234"
+    scheme: str = "http"
+    authority: str | None = None
+    headers: _Headers = field(default_factory=_Headers)
+
+
+class _MockMessage:
+    """Mirrors :class:`granian.rsgi.WebsocketMessage` (kind / data)."""
+
+    __slots__ = ("data", "kind")
+
+    def __init__(self, kind: int, data: Any) -> None:
+        self.kind = kind
+        self.data = data
+
+
+class _MockTransport:
+    """Stand-in for :class:`granian.rsgi.RSGIWebsocketTransport`."""
+
+    def __init__(self, incoming: list[_MockMessage]) -> None:
+        self._incoming = list(incoming)
+        self.sent: list[tuple[str, Any]] = []
+
+    async def receive(self) -> _MockMessage:
+        if not self._incoming:
+            return _MockMessage(0, b"")
+        return self._incoming.pop(0)
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(("text", data))
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent.append(("bytes", bytes(data)))
+
+
+class _MockProtocol:
+    """Stand-in for :class:`granian.rsgi.RSGIWebsocketProtocol`."""
+
+    def __init__(self, incoming: list[_MockMessage] | None = None) -> None:
+        self._incoming = incoming or []
+        self.transport: _MockTransport | None = None
+        self.closed_with: int | None = None
+
+    async def accept(self) -> _MockTransport:
+        self.transport = _MockTransport(self._incoming)
+        return self.transport
+
+    def close(self, status: int | None) -> tuple[int, bool]:
+        self.closed_with = int(status) if status is not None else 1000
+        return (self.closed_with, True)
+
+
+def _drive(app: App, scope: Any, proto: Any) -> None:
+    """Run ``app.handle_rsgi(scope, proto)`` to completion on a fresh event loop.
+
+    ``pyo3-async-runtimes`` needs an active asyncio loop *at the moment* the Rust
+    side calls ``future_into_py``, so we always invoke ``handle_rsgi`` from inside
+    a coroutine rather than synchronously from the test body.
+    """
+
+    async def _inner() -> None:
+        await app.handle_rsgi(scope, proto)
+
+    asyncio.run(_inner())
+
+
+def test_websocket_decorator_registers_route() -> None:
+    app = App()
+
+    @app.websocket("/ws")
+    async def handler(ws: WebSocket) -> None:
+        await ws.accept()
+        await ws.close()
+
+    assert handler.__name__ == "handler"
+
+
+def test_websocket_echo_round_trip() -> None:
+    app = App()
+
+    @app.websocket("/ws/:room")
+    async def echo(ws: WebSocket) -> None:
+        assert ws.path_params["room"] == "lobby"
+        await ws.accept()
+        msg = await ws.receive_text()
+        await ws.send_text(f"echo:{msg}")
+        await ws.send_bytes(b"binary")
+        await ws.close()
+
+    proto = _MockProtocol(incoming=[_MockMessage(2, "hello")])
+    _drive(app, _WSScope(path="/ws/lobby"), proto)
+
+    assert proto.transport is not None
+    assert proto.transport.sent == [("text", "echo:hello"), ("bytes", b"binary")]
+    assert proto.closed_with == 1000
+
+
+def test_websocket_send_json() -> None:
+    app = App()
+
+    @app.websocket("/json")
+    async def push_json(ws: WebSocket) -> None:
+        await ws.accept()
+        await ws.send_json({"a": 1, "b": [2, 3]})
+        await ws.close()
+
+    proto = _MockProtocol()
+    _drive(app, _WSScope(path="/json"), proto)
+
+    assert proto.transport is not None
+    assert proto.transport.sent[0][0] == "text"
+    import json
+
+    assert json.loads(proto.transport.sent[0][1]) == {"a": 1, "b": [2, 3]}
+
+
+def test_websocket_no_route_closes_polite() -> None:
+    app = App()
+    proto = _MockProtocol()
+    _drive(app, _WSScope(path="/missing"), proto)
+    assert proto.closed_with == 1000
+    assert proto.transport is None
+
+
+def test_websocket_handler_error_closes_with_1011() -> None:
+    app = App()
+
+    @app.websocket("/boom")
+    async def boom(ws: WebSocket) -> None:
+        await ws.accept()
+        raise RuntimeError("boom")
+
+    proto = _MockProtocol()
+    _drive(app, _WSScope(path="/boom"), proto)
+    assert proto.closed_with == 1011
+
+
+def test_websocket_peer_close_marks_closed() -> None:
+    """When the peer sends a close frame, ``receive_text`` raises and our side
+    must not redundantly call ``protocol.close()`` (Granian handled the close).
+    """
+
+    app = App()
+    after_state: dict[str, Any] = {}
+
+    @app.websocket("/peer-close")
+    async def peer_close(ws: WebSocket) -> None:
+        await ws.accept()
+        with pytest.raises(RuntimeError, match="closed by peer"):
+            await ws.receive_text()
+        after_state["is_closed"] = ws.is_closed
+        await ws.close()
+
+    proto = _MockProtocol(incoming=[_MockMessage(0, b"")])
+    _drive(app, _WSScope(path="/peer-close"), proto)
+    assert after_state["is_closed"] is True
+    assert proto.closed_with is None
+
+
+def test_websocket_kind_mismatch_raises_value_error() -> None:
+    app = App()
+
+    @app.websocket("/strict-text")
+    async def strict_text(ws: WebSocket) -> None:
+        await ws.accept()
+        with pytest.raises(ValueError):
+            await ws.receive_text()
+        await ws.close()
+
+    proto = _MockProtocol(incoming=[_MockMessage(1, b"binary-not-text")])
+    _drive(app, _WSScope(path="/strict-text"), proto)
+
+
+def test_websocket_send_before_accept_raises() -> None:
+    app = App()
+
+    @app.websocket("/no-accept")
+    async def no_accept(ws: WebSocket) -> None:
+        with pytest.raises(RuntimeError, match="accept"):
+            await ws.send_text("nope")
+        await ws.close()
+
+    proto = _MockProtocol()
+    _drive(app, _WSScope(path="/no-accept"), proto)
+
+
+def test_websocket_frozen_app_rejects_route() -> None:
+    app = App()
+    app.freeze()
+    with pytest.raises(ValueError, match="frozen"):
+
+        @app.websocket("/late")
+        async def late(ws: WebSocket) -> None: ...


### PR DESCRIPTION
Closes #90.

> ⚠️ **Depends on #89** (`issue-88-drop-asgi`). Base is set to that branch on
> purpose; merge order should be #89 → main → #90 rebased onto `dev`.

## Summary

OxyRoute v0.3.0 dropped the ASGI bridge alongside the legacy ASGI WebSocket
spike. This PR re-introduces WebSocket support **natively over RSGI**, with no
Python helper class and no second event loop.

- New Rust `WebSocket` pyclass (`oxyroute._oxyroute.WebSocket`) wraps Granian's
  `RSGIWebsocketProtocol` / transport. `accept`, `receive` /
  `receive_text` / `receive_bytes`, `send_text` / `send_bytes` / `send_json`
  and `close(code=None)` all return real awaitables that delegate to the
  underlying Granian coroutines via `pyo3_async_runtimes::tokio::into_future`.
- `App.add_websocket_route(path, handler)` registers in a dedicated
  `matchit::Router` next to the HTTP routers (also covered by `freeze()`'s
  compiled snapshot for lock-free lookup).
- `run_rsgi` branches on `scope.proto == "websocket"` to a new
  `run_rsgi_websocket` dispatcher. Unknown paths → polite `close(1000)`;
  handler errors → `close(1011)`.
- Python-side `@app.websocket(path)` decorator + `oxyroute.WebSocket`
  re-exported from the package.

## Test plan

- [x] `tests/test_websocket_native.py` — 9 cases covering: echo round-trip
      with path params (text + bytes), `send_json`, no-route close, handler
      raise → 1011, peer-side close (kind=0) → no double close, frame kind
      mismatch, send-before-accept, frozen app rejects new ws routes.
- [x] Full `pytest` (102 / 102) green.
- [x] `cargo fmt` / `cargo clippy --all-targets -- -D warnings` clean.
- [x] `ruff check` / `ruff format --check` clean on Python sources.

## Out of scope / follow-ups

- End-to-end Granian + real WS client subprocess test (deferred — covered by
  the existing pattern in `tests/test_granian_e2e.py`).
- Subprotocol negotiation hooks (Granian negotiates via headers; the helper
  intentionally does not expose a subprotocol parameter on `accept`).