### PR TITLE
feat(rsgi): native websocket, sync short-circuit, and bench harness hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.0] - unreleased
 
+### Added
+
+- Native RSGI WebSocket support: `@app.websocket(path)` and `oxyroute.WebSocket` are
+  exported from the package and dispatched directly inside the Rust extension. No ASGI
+  shim is involved; the helper class wraps Granian's `RSGIWebsocketProtocol` and exposes
+  `accept`, `receive` / `receive_text` / `receive_bytes`, `send_text` / `send_bytes` /
+  `send_json`, and `close`. Path matching uses the same `matchit` syntax as HTTP routes
+  and lives in its own router. Unknown paths produce a polite `close(1000)`; handler
+  errors trigger `close(1011)`.
+
 ### Removed (breaking)
 
 - The optional ASGI 3.0 compatibility bridge (`oxyroute.asgi`) was removed. `App` is no
@@ -15,7 +25,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ``granian --interface rsgi``.
 - The ASGI-based `@app.websocket(path)` decorator and the
   `App._handle_asgi_websocket` plumbing were removed alongside the bridge. Native RSGI
-  WebSocket support will be reintroduced in a follow-up release.
+  WebSocket support is reintroduced in this release (see *Added*).
 
 ### Migration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OxyRoute
 
-**RSGI-first** web toolkit: HTTP routing, JSON handling, and HS\* JWT validation on a **Rust** hot path ([PyO3](https://pyo3.rs/) + [Maturin](https://www.maturin.rs/)), with your business logic in ordinary **Python** handlers. Pair it with **[Granian](https://github.com/emmett-framework/granian)** using `--interface rsgi` for the intended stack.
+**RSGI-first** web toolkit: HTTP routing, JSON/form handling, JWT validation, response mapping, and native WebSockets on a **Rust** hot path ([PyO3](https://pyo3.rs/) + [Maturin](https://www.maturin.rs/)), with your business logic in ordinary **Python** handlers. Pair it with **[Granian](https://github.com/emmett-framework/granian)** using `--interface rsgi` for the intended stack.
 
 [![CI](https://github.com/QueryaHub/OxyRoute/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/QueryaHub/OxyRoute/actions)
 
@@ -8,13 +8,15 @@
 
 - **RSGI** entrypoint (`async def __rsgi__(scope, protocol)`) compatible with Granian’s RSGI implementation
 - **Routing** via [matchit](https://crates.io/crates/matchit) (path parameters like `/users/:id`)
-- **JSON bodies** parsed in Rust; successful values passed to handlers as kwargs
-- **JWT (HMAC)** verification on the Rust path before your handler runs (`require_jwt`, HS256/384/512)
+- **JSON, form, and multipart bodies** parsed on the native path; successful values passed to handlers as kwargs
+- **JWT** verification on the Rust path before your handler runs (`require_jwt`, HS*, RSA, EC, EdDSA public-key verification)
 - **Optional** `GET /openapi.json` with a minimal OpenAPI-style document
 - **Dependencies**: linear list of named factories (`Depends`, sync or async) passed as kwargs
+- **Optional middleware layers** for pre-route decisions, CORS, CSRF, and browser security headers
+- **Native RSGI WebSockets** via `@app.websocket(path)` and `oxyroute.WebSocket`
 - Native extension wheel (abi3) for **Python ≥ 3.10**
 
-Full documentation: **[docs/index.md](docs/index.md)**
+Start with the full **[Usage guide](docs/usage.md)**, or use **[docs/index.md](docs/index.md)** for topic-specific pages.
 
 ## Requirements
 
@@ -60,8 +62,8 @@ def root() -> str:
 
 
 @app.get("/hello/:name")
-def hello_name(**kwargs) -> str:
-    return f"Hello, {kwargs.get('name', '')}"
+def hello_name(name: str) -> dict:
+    return {"message": f"Hello, {name}"}
 ```
 
 Run (from the repo, after `maturin develop` or an editable install):
@@ -73,6 +75,19 @@ granian --interface rsgi examples.rsgi_app:app
 Per-worker setup (`__rsgi_init__`) is shown in [examples/rsgi_lifespan_app.py](examples/rsgi_lifespan_app.py) and [docs/rsgi.md](docs/rsgi.md#lifespan-optional).
 
 OxyRoute v0.3.0 supports **only** Granian RSGI; the legacy ASGI bridge (`uvicorn` / `granian --interface asgi`) was removed.
+
+## Usage docs
+
+- [Usage guide](docs/usage.md) — install, run, routing, bodies, responses, middleware, CORS, CSRF, JWT, WebSockets, deployment notes, limitations
+- [RSGI and Granian](docs/rsgi.md) — app entrypoint, lifespan hooks, worker process model
+- [Handlers](docs/handlers.md) — injected parameters and response mapping details
+- [Routing](docs/routing.md) — methods, path syntax, `APIRouter`, `freeze()`
+- [JWT](docs/jwt.md), [CORS](docs/cors.md), [CSRF](docs/csrf.md), [Security headers](docs/security-headers.md)
+- [WebSockets](docs/websocket.md) and [SSE](docs/sse.md)
+
+## Production notes
+
+OxyRoute is designed for Granian RSGI deployments. For public traffic, place it behind a normal production boundary (TLS, request-size limits, timeouts, logging, process supervision) and keep `OXYROUTE_DEBUG` disabled. Request bodies and multipart files are currently buffered in memory before parsing, so enforce limits both at the edge and with `OXYROUTE_MAX_BODY_BYTES`.
 
 ## Project layout
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,11 +53,11 @@ The workflow at `.github/workflows/ci.yml` (job name: **ci**):
 
 ## Releasing to PyPI
 
-Tag a release with a **`v`-prefixed** semver tag (example: **`v0.2.0`**). That triggers `.github/workflows/release-pypi.yml`, which builds an **sdist**, **manylinux** x86_64 wheels, **Windows** x64, and **macOS** arm64 + x86_64 wheels, then uploads to **PyPI** using a **project-scoped API token** stored in GitHub as **`PYPI_API_TOKEN`** (Secret or Environment variable) on the **`pypi`** environment. The publish step uses `secrets` first, then `vars` (so you can start with a variable and move the value to a **Secret** later).
+Tag a release with a **`v`-prefixed** semver tag (example: **`v0.3.0`**). That triggers `.github/workflows/release-pypi.yml`, which builds an **sdist**, **manylinux** x86_64 wheels, **Windows** x64, and **macOS** arm64 + x86_64 wheels, then uploads to **PyPI** using a **project-scoped API token** stored in GitHub as **`PYPI_API_TOKEN`** (Secret or Environment variable) on the **`pypi`** environment. The publish step uses `secrets` first, then `vars` (so you can start with a variable and move the value to a **Secret** later).
 
 **Before the first upload:**
 
-1. Keep **`pyproject.toml`**, **`Cargo.toml`**, and **`oxyroute/__init__.py`** `__version__` in sync with the version you are releasing, and with the tag (e.g. `0.2.0` → tag `v0.2.0`).
+1. Keep **`pyproject.toml`**, **`Cargo.toml`**, and **`oxyroute/__init__.py`** `__version__` in sync with the version you are releasing, and with the tag (e.g. `0.3.0` → tag `v0.3.0`).
 2. On [PyPI](https://pypi.org), create a **scoped API token** for this project, then in GitHub → **Settings → Environments** create the **`pypi`** environment and add **`PYPI_API_TOKEN`** (strongly prefer an **Environment secret** over a **Variable**; tokens in Variables are visible to people with access to the environment).
 3. Optional alternative to API tokens: [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no long-lived token; then the workflow’s publish job should omit `with.password` and set `id-token: write` (see the PyPA action README).
 

--- a/docs/feature.md
+++ b/docs/feature.md
@@ -2,7 +2,10 @@
 
 Документ фиксирует **разрыв** между текущим OxyRoute (RSGI + Rust hot path, см. [index](index.md)) и ожиданиями от **широкого** HTTP-фреймворка уровня FastAPI / Starlette / Django REST. Термин «полноценный» здесь означает **покрытие типичного продакшн-API и DX**, а не обязательность всех пунктов для твоего позиционирования.
 
-**Следующий релиз:** в репозитории и в GitHub milestone целим **0.2.0** / [**v0.2.0**](https://github.com/QueryaHub/OxyRoute/milestone/1) (не 0.3.0); см. [PRIORITIES](../.github/ISSUE_BACKLOG/PRIORITIES.md).
+**Текущий контекст:** документация ниже описывает состояние ветки v0.3.x: OxyRoute
+теперь **RSGI-only**, ASGI bridge удалён, native RSGI WebSocket реализован, а часть
+пунктов из старого research уже закрыта. Для практического использования см.
+[usage.md](usage.md).
 
 ---
 
@@ -12,7 +15,8 @@
 - **JWT** (HS/RS/… через `jsonwebtoken`), iss/aud/leeway, cookie, **зависимости** с `request`, линейный порядок, `freeze`.
 - **Response** / dict с заголовками и cookies, частичный **OpenAPI**, Pydantic/schema для тела.
 - Один **pre-route middleware** (`set_middleware`).
-- CI, PyPI, E2E Granian RSGI.
+- Native RSGI **WebSocket** (`@app.websocket`, `oxyroute.WebSocket`), SSE helper.
+- CI, PyPI, E2E/bench harness для Granian RSGI.
 
 Ниже — то, чего **нет** или что **слабо** относительно «больших» фреймворков.
 
@@ -22,7 +26,7 @@
 
 | Тема | Зазор | Комментарий |
 |------|--------|-------------|
-| **WebSockets** | Не реализованы | Поддержка ASGI WS была удалена в v0.3.0; native RSGI WebSocket — следующая работа. |
+| **WebSockets** | Реализованы | Native RSGI WebSocket: `@app.websocket(path)`, `oxyroute.WebSocket`; см. [websocket.md](websocket.md). Нет high-level subprotocol API. |
 | **SSE / длинный стрим ответа** | Частично | Есть `send_sse` (см. [sse.md](sse.md)); инкрементальный стрим использует `response_stream` Granian RSGI. |
 | **HTTP/2 push, trailers** | Не в фокусе | Обычно на стороне сервера; фреймворк редко экспонирует. |
 | **ASGI совместимость** | Удалена в v0.3.0 | Поддерживается только RSGI (Granian `--interface rsgi`). |
@@ -78,7 +82,7 @@
 
 | Тема | Зазор | Комментарий |
 |------|--------|-------------|
-| **TestClient** (как Starlette/FastAPI) | Нет | Тесты через httpx + ASGI/реальный Granian; нет единого обёрточного клиента из коробки. |
+| **TestClient** (как Starlette/FastAPI) | Нет | Тесты через in-process RSGI shims или реальный Granian; нет единого обёрточного клиента из коробки. |
 | **CLI** (`oxyroute dev`, scaffold) | Нет | |
 | **OpenAPI генерация клиентов** | Частично | Документ есть; не обещается полная совместимость со всеми генераторами. |
 | **Background tasks** | Нет | Нет `BackgroundTasks` после ответа; только внешний воркер/очередь. |
@@ -101,20 +105,24 @@
 - **Шаблоны HTML (Jinja)** — нет; для API не критично.
 - **GraphQL / gRPC** — отдельные стеки.
 
-OxyRoute осознанно **уже** в нише: **быстрый маршрут + JSON + JWT в Rust**. «Полноценность» для многих команд = **multipart, WebSocket, цепочка middleware, суброутеры, TestClient** — это хороший кандидат на дорожную карту, если цель — конкурировать с FastAPI по удобству, а не только по RSGI.
+OxyRoute осознанно **уже** в нише: быстрый RSGI HTTP/WebSocket слой с routing,
+JSON/form/JWT/headers на Rust hot path и Python business logic. «Полноценность»
+для многих команд теперь упирается меньше в протокол, а больше в **стриминг тела
+запроса**, **цепочку middleware**, **TestClient**, **observability**, **rate limit**
+и **production security automation**.
 
 ---
 
 ## Приоритизация (рекомендация)
 
-1. **Состояние и lifecycle** [#18](https://github.com/QueryaHub/OxyRoute/issues/18) — без этого сложно делить конфиг по воркерам.  
-2. **ASGI надёжность** [#17](https://github.com/QueryaHub/OxyRoute/issues/17) — если ASGI остаётся равноправным входом.  
-3. **Перф роутера** [#4](https://github.com/QueryaHub/OxyRoute/issues/4) — при росте нагрузки.  
-4. **Sub-routers или префиксы** — резко повышают пригодность для крупных приложений.  
-5. **Multipart + form body** — если не только JSON API.  
-6. **Exception handlers (глобальные)** — быстрые победы на Python-стороне без ломки RSGI. **CORS** — см. [cors.md](cors.md) / [#49](https://github.com/QueryaHub/OxyRoute/issues/49).
+1. **Streaming / early body limiting** — сейчас body и multipart читаются в память.
+2. **Middleware chain** — сейчас один pre-route hook, compose вручную.
+3. **TestClient** — единый удобный клиент поверх RSGI shim.
+4. **Observability** — metrics/tracing/access-log story.
+5. **Exception handlers (глобальные)** — удобный слой поверх текущего `HTTPException`.
+6. **JWKS / key rotation** — production auth удобство.
 
-## Связанные GitHub-issues (milestone v0.2.0)
+## Связанные GitHub-issues и исторический backlog
 
 **Композиция и тело / ошибки / CORS**
 
@@ -126,7 +134,7 @@ OxyRoute осознанно **уже** в нише: **быстрый маршр�
 
 - [#50](https://github.com/QueryaHub/OxyRoute/issues/50) — HTTP/2 (док/Granian) ([`25.md`](../.github/ISSUE_BACKLOG/bodies/25.md))  
 - [#51](https://github.com/QueryaHub/OxyRoute/issues/51) — SSE ([`26.md`](../.github/ISSUE_BACKLOG/bodies/26.md))  
-- [#52](https://github.com/QueryaHub/OxyRoute/issues/52) — WebSocket ([`27.md`](../.github/ISSUE_BACKLOG/bodies/27.md))  
+- [#52](https://github.com/QueryaHub/OxyRoute/issues/52) — WebSocket ([`27.md`](../.github/ISSUE_BACKLOG/bodies/27.md)) — **закрыто native RSGI WS**  
 - [#53](https://github.com/QueryaHub/OxyRoute/issues/53) — CSRF ([`28.md`](../.github/ISSUE_BACKLOG/bodies/28.md), [csrf.md](csrf.md)) — **сделано**  
 - [#54](https://github.com/QueryaHub/OxyRoute/issues/54) — security headers ([`29.md`](../.github/ISSUE_BACKLOG/bodies/29.md), [security-headers.md](security-headers.md)) — **сделано**  
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ Granian still invokes a Python `App` object; the “win” is doing routing, bod
 
 | Topic | Description |
 |--------|-------------|
+| [Usage guide](usage.md) | End-to-end reference: install, run, routing, bodies, responses, middleware, CORS/CSRF/JWT, WebSockets, production notes |
 | [Installation](installation.md) | `pip`, `oxyroute[dev]`, building with Cargo/maturin, troubleshooting |
 | [RSGI and Granian](rsgi.md) | Why RSGI, `__rsgi__`, lifespan hooks, spec link |
 | [Routing](routing.md) | Path patterns, methods, 404s |
@@ -52,7 +53,7 @@ Granian still invokes a Python `App` object; the “win” is doing routing, bod
 | [OpenAPI](openapi.md) | `openapi.json` route, title, `openapi_json()` |
 | [Development](development.md) | Tests, CI, PyPI releases (tag `v*`), clippy, pytest |
 | [Branching and PRs](development-workflow.md) | `dev` as base, issue branches, `Closes #N`, no mixing code with `ISSUE_BACKLOG` in one commit |
-| [Feature gaps (research)](feature.md) | What is missing vs a “full” HTTP framework (multipart, WS, sub-routers, etc.) — Russian |
+| [Feature gaps (research)](feature.md) | What is missing vs a “full” HTTP framework and what has been implemented — Russian |
 | [Contributing](../CONTRIBUTING.md) | Local setup, issue backlog, GitHub `gh` workflow |
 
 [← Back to project README](../README.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ Granian still invokes a Python `App` object; the “win” is doing routing, bod
 | [CSRF](csrf.md) | Double-submit, `apply_csrf`, `csrf_layer` + CORS |
 | [JWT](jwt.md) | `require_jwt`, HS* / RSA / EC PEM, `decode_jwt_hs` (HS* tests) |
 | [SSE](sse.md) | `send_sse`, event framing, streaming caveats |
+| [WebSockets](websocket.md) | Native RSGI `@app.websocket(path)` and `oxyroute.WebSocket` |
 | [HTTP/2 with Granian](http2.md) | Transport guarantees vs server/proxy responsibilities |
 | [Dependencies](dependencies.md) | `Depends`, `dependencies=[...]`, `freeze` |
 | [OpenAPI](openapi.md) | `openapi.json` route, title, `openapi_json()` |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,581 @@
+# Usage guide
+
+[← Documentation index](index.md)
+
+This guide is the recommended end-to-end reference for using OxyRoute as an
+application framework. It describes the current **v0.3.0** behavior: OxyRoute is
+**RSGI-only** and is intended to run behind **Granian** with `--interface rsgi`.
+The removed ASGI bridge is not part of the supported runtime path.
+
+## Minimal application
+
+Create `app.py`:
+
+```python
+from oxyroute import App
+
+app = App(title="Example API")
+
+
+@app.get("/")
+def root() -> str:
+    return "ok"
+
+
+@app.get("/users/:user_id")
+def get_user(user_id: int, query: dict[str, str] | None = None) -> dict:
+    return {"user_id": user_id, "query": query or {}}
+```
+
+Run with Granian:
+
+```bash
+granian app:app --interface rsgi --host 127.0.0.1 --port 8000
+```
+
+For multiple worker processes:
+
+```bash
+granian app:app --interface rsgi --host 0.0.0.0 --port 8000 --workers 2
+```
+
+Each worker is a separate process. In-memory state is **not shared** across
+workers; use external storage for sessions, counters, queues, and durable state.
+
+## Install
+
+From PyPI, once published:
+
+```bash
+pip install oxyroute granian
+```
+
+From a checkout:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip maturin
+maturin develop
+pip install granian
+```
+
+For tests and local development extras:
+
+```bash
+pip install "oxyroute[dev]"
+```
+
+For benchmark extras:
+
+```bash
+pip install "oxyroute[bench]"
+```
+
+See [installation.md](installation.md) for troubleshooting native builds.
+
+## Application object
+
+```python
+from oxyroute import App
+
+app = App(title="My API", include_openapi=True)
+```
+
+Constructor options:
+
+| Option | Default | Meaning |
+|---|---:|---|
+| `title` | `"OxyRoute"` | Stored in the generated OpenAPI document. |
+| `include_openapi` | `True` | Serve built-in `GET` / `HEAD /openapi.json`. |
+
+Runtime methods:
+
+| Method | Meaning |
+|---|---|
+| `app.freeze()` | Reject new route registrations and build a read-only routing snapshot. The app also auto-builds this snapshot on first request if you do not call `freeze()`. |
+| `app.set_openapi_served(False)` | Stop serving built-in `/openapi.json`; the in-memory document still exists. |
+| `app.openapi_json()` | Return the current OpenAPI JSON string even when serving is disabled. |
+| `app.set_middleware(fn_or_none)` | Enable or disable one optional pre-route callback. |
+| `app.set_cors(config_or_none)` | Enable or disable CORS header merging. |
+| `app.set_security_headers(config_or_none)` | Enable or disable browser security header merging. |
+
+## Routing
+
+OxyRoute uses `matchit`-style patterns:
+
+```python
+@app.get("/items/:id")
+def item(id: int) -> dict:
+    return {"id": id}
+```
+
+Supported HTTP decorator methods:
+
+- `app.get`
+- `app.post`
+- `app.put`
+- `app.patch`
+- `app.delete`
+- `app.options`
+
+`HEAD` uses the `GET` router and strips the response body while preserving the
+expected `Content-Length` where possible.
+
+Unknown routes return:
+
+- `404 Not Found` when no method matches the path.
+- `405 Method Not Allowed` with an `Allow` header when another method matches
+  the same path.
+
+Unsupported HTTP methods raise a routing error in the native layer.
+
+## Routers and prefixes
+
+Use `APIRouter` to group routes and mount them under a prefix:
+
+```python
+from oxyroute import APIRouter, App
+
+api = APIRouter()
+
+
+@api.get("/users/:id")
+def user(id: int) -> dict:
+    return {"id": id}
+
+
+app = App()
+app.include_router(api, prefix="/api/v1")
+```
+
+`include_router(..., **defaults)` can pass route defaults such as JWT settings or
+dependencies. Per-route options win over defaults.
+
+## Handler parameters
+
+Handlers are called with keyword arguments. OxyRoute only passes values that the
+handler accepts by name, unless the handler has `**kwargs`.
+
+```python
+@app.get("/search/:kind")
+def search(kind: str, query: dict[str, str]) -> dict:
+    return {"kind": kind, "query": query}
+```
+
+Common injected names:
+
+| Name | When present | Value |
+|---|---|---|
+| Path params | Route pattern captures them | Coerced to common Python types when possible (`int`, `float`, `bool`, `str`). |
+| `query` | Query string exists | `dict[str, str]`, percent-decoded, duplicate keys are last-wins. |
+| `json` | `read_json_body=True` and JSON body parses | Python object converted from JSON. |
+| `form` | `read_form_body=True` | Form fields as `dict[str, str]`. |
+| `files` | Multipart form with file parts | List of dictionaries with `name`, optional `filename`, `content_type`, and `data` bytes. |
+| `body` | Handler asks for raw body and JSON/form modes do not consume it | Raw `bytes`. |
+| `protocol` | Handler declares `protocol` | Underlying RSGI protocol object for advanced flows such as SSE. |
+| `claims` | Route uses `require_jwt=True` and token verifies | Decoded JWT claims object. |
+| Dependency names | Route declares `dependencies=[(...)]` | Return values of dependency factories. |
+
+## Request bodies
+
+For `POST`, `PUT`, and `PATCH`, JSON body parsing is enabled by default:
+
+```python
+@app.post("/items")
+def create_item(json: dict) -> dict:
+    return {"created": json}
+```
+
+For form bodies:
+
+```python
+@app.post("/submit", read_form_body=True)
+def submit(form: dict[str, str]) -> dict:
+    return {"form": form}
+```
+
+For multipart:
+
+```python
+@app.post("/upload", read_form_body=True)
+def upload(form: dict[str, str], files: list[dict]) -> dict:
+    return {"fields": form, "file_count": len(files)}
+```
+
+Important production note: request bodies are currently buffered in memory before
+parsing. The default limit is **8 MiB**, controlled by `OXYROUTE_MAX_BODY_BYTES`.
+Set a stricter limit at the deployment boundary (reverse proxy / server) for
+untrusted public traffic.
+
+## Return values
+
+Simple returns:
+
+```python
+@app.get("/text")
+def text() -> str:
+    return "hello"
+
+
+@app.get("/json")
+def json_response() -> dict:
+    return {"ok": True}
+
+
+@app.get("/bytes")
+def bytes_response() -> bytes:
+    return b"raw"
+```
+
+Mapping rules:
+
+| Return value | Response |
+|---|---|
+| `str` | `200 text/plain; charset=utf-8` |
+| `bytes` | `200 application/octet-stream` |
+| `dict`, `list`, other JSON-serializable object | `200 application/json; charset=utf-8` |
+| `Response` | Custom status/body/headers/cookies |
+| Dict with `status`, `body`, optional `headers` / `cookies` | Structured response path |
+| `None` | Empty response where supported by the response mapper |
+
+Use `Response` when you need explicit status, content type, or cookies:
+
+```python
+from oxyroute import Response
+
+
+@app.get("/created")
+def created() -> Response:
+    return Response(
+        status=201,
+        body={"ok": True},
+        headers={"x-example": "yes"},
+        cookies=["session=abc; HttpOnly; SameSite=Lax"],
+    )
+```
+
+## Error responses
+
+Raise `HTTPException` for expected HTTP errors:
+
+```python
+from oxyroute import HTTPException
+
+
+@app.get("/items/:id")
+def item(id: int) -> dict:
+    if id < 0:
+        raise HTTPException(400, "id must be positive")
+    return {"id": id}
+```
+
+Other uncaught exceptions become `500` with a generic JSON body by default:
+
+```json
+{"error":"internal server error"}
+```
+
+Set `OXYROUTE_DEBUG=1` only in safe development environments if you need the
+error detail in responses.
+
+## Middleware and optional layers
+
+OxyRoute does **not** enable middleware, CORS, or security headers by default.
+All of these are opt-in and can be disabled by passing `None`.
+
+### Pre-route middleware
+
+There is one optional pre-route callback:
+
+```python
+def block_health_probe(scope, protocol):
+    if getattr(scope, "path", "") == "/blocked":
+        return {"status": 403, "body": {"error": "blocked"}}
+    return None
+
+
+app.set_middleware(block_health_probe)
+```
+
+Behavior:
+
+- Runs before route matching and before body reading.
+- Return `None` to continue.
+- Return any mapped response value to send that response immediately.
+- `app.set_middleware(None)` disables it.
+
+Because middleware must run, enabling it disables some synchronous short-circuit
+optimizations for built-in OpenAPI / 404 / 405 paths.
+
+### CORS
+
+Use `apply_cors` for normal browser API usage:
+
+```python
+from oxyroute import CORSConfig, apply_cors
+
+apply_cors(
+    app,
+    CORSConfig(
+        allow_origins=["https://frontend.example"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["authorization", "content-type"],
+        allow_credentials=True,
+    ),
+)
+```
+
+`apply_cors` configures response header merging and installs a preflight
+middleware. If you only want response header merging, use `app.set_cors(config)`.
+Disable with `app.set_cors(None)` and, if `apply_cors` installed middleware,
+replace or clear middleware with `app.set_middleware(...)`.
+
+### Security headers
+
+```python
+from oxyroute import SecurityHeadersConfig
+
+app.set_security_headers(
+    SecurityHeadersConfig(
+        hsts="max-age=31536000; includeSubDomains",
+        content_security_policy="default-src 'none'; frame-ancestors 'none'",
+    )
+)
+```
+
+Disable with:
+
+```python
+app.set_security_headers(None)
+```
+
+HSTS is emitted only when the request scheme is `https`.
+
+### CSRF
+
+CSRF is opt-in and intended for browser flows that rely on cookies for
+authentication. Typical APIs that use only Authorization headers may not need it.
+
+```python
+from oxyroute import CSRFConfig, apply_csrf
+
+apply_csrf(app, CSRFConfig(secret="change-me"))
+```
+
+See [csrf.md](csrf.md) for token flow and CORS composition.
+
+## JWT-protected routes
+
+```python
+@app.get(
+    "/private",
+    require_jwt=True,
+    jwt_secret="dev-secret",
+    algorithms=["HS256"],
+)
+def private(claims: dict) -> dict:
+    return {"sub": claims.get("sub")}
+```
+
+For asymmetric algorithms, `jwt_secret` is the public key PEM used for
+verification:
+
+```python
+@app.get(
+    "/admin",
+    require_jwt=True,
+    jwt_secret=PUBLIC_KEY_PEM,
+    algorithms=["RS256"],
+    jwt_issuer="https://issuer.example",
+    jwt_audience="api",
+)
+def admin(claims: dict) -> dict:
+    return claims
+```
+
+If `jwt_cookie="name"` is configured, OxyRoute can read a token from that cookie
+when there is no usable `Authorization: Bearer ...` header.
+
+## Dependencies
+
+Dependencies are a linear, named list:
+
+```python
+from oxyroute import Depends
+
+
+def settings() -> dict:
+    return {"region": "eu"}
+
+
+async def user(settings: dict) -> dict:
+    return {"name": "alice", "region": settings["region"]}
+
+
+@app.get("/me", dependencies=[("settings", Depends(settings)), ("user", Depends(user))])
+def me(user: dict) -> dict:
+    return user
+```
+
+Later dependency factories receive earlier dependency values by name. Route
+handlers receive only dependency names they declare, unless they use `**kwargs`.
+
+## WebSockets
+
+Native WebSockets use the same RSGI app and Granian process:
+
+```python
+from oxyroute import WebSocket
+
+
+@app.websocket("/ws/:room")
+async def chat(ws: WebSocket) -> None:
+    await ws.accept()
+    await ws.send_text(f"room={ws.path_params['room']}")
+    while True:
+        msg = await ws.receive_text()
+        if msg == "bye":
+            await ws.close()
+            return
+        await ws.send_text(f"echo:{msg}")
+```
+
+Run:
+
+```bash
+granian app:app --interface rsgi
+```
+
+Unknown WebSocket paths are closed with code `1000`; handler errors close with
+`1011`. Add application-level origin/auth checks as needed for your deployment.
+
+## SSE and streaming-style responses
+
+For Server-Sent Events, ask for the `protocol` parameter and use `send_sse`.
+It accepts an iterable or async iterable of `str` / `SSEEvent` and returns the
+marker object that tells OxyRoute the response has already been sent:
+
+```python
+from oxyroute import SSEEvent, send_sse
+
+
+@app.get("/events")
+async def events(protocol):
+    return await send_sse(protocol, [SSEEvent(data="hello")])
+```
+
+See [sse.md](sse.md) for details and caveats.
+
+## OpenAPI
+
+`GET /openapi.json` and `HEAD /openapi.json` are served by default. Disable:
+
+```python
+app = App(include_openapi=False)
+# or later:
+app.set_openapi_served(False)
+```
+
+You can still export the document:
+
+```python
+spec_json = app.openapi_json()
+```
+
+Request body schemas can be documented with either `body_model=` (Pydantic v2)
+or `body_schema=` on `post`, `put`, and `patch` routes.
+
+## Lifespan and per-worker state
+
+Subclass `App` when you need per-worker setup/teardown:
+
+```python
+from oxyroute import App
+
+
+class MyApp(App):
+    async def __rsgi_init__(self, *args, **kwargs) -> None:
+        self.state.ready = True
+
+    async def __rsgi_del__(self, *args, **kwargs) -> None:
+        self.state.ready = False
+
+
+app = MyApp()
+```
+
+`app.state` is a `types.SimpleNamespace`. It is per process, not shared between
+Granian workers.
+
+## Recommended production shape
+
+Minimal production-facing shape:
+
+```python
+from oxyroute import App, CORSConfig, SecurityHeadersConfig, apply_cors
+
+app = App(title="Production API", include_openapi=False)
+
+apply_cors(
+    app,
+    CORSConfig(
+        allow_origins=["https://frontend.example"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["authorization", "content-type"],
+        allow_credentials=True,
+    ),
+)
+
+app.set_security_headers(
+    SecurityHeadersConfig(
+        hsts="max-age=31536000; includeSubDomains",
+        content_security_policy="default-src 'none'; frame-ancestors 'none'",
+    )
+)
+
+
+@app.get("/health")
+def health() -> str:
+    return "ok"
+
+
+app.freeze()
+```
+
+Run behind a reverse proxy or platform that handles TLS, request-size limits,
+timeouts, logging, and process supervision:
+
+```bash
+granian app:app --interface rsgi --host 0.0.0.0 --port 8000 --workers 2
+```
+
+Production checklist:
+
+- Set body-size limits at the edge as well as `OXYROUTE_MAX_BODY_BYTES`.
+- Do not expose `/openapi.json` publicly unless intended.
+- Use explicit JWT algorithms and issuer/audience checks for protected routes.
+- Use `apply_cors` only for trusted origins; avoid `allow_origins=["*"]` with credentials.
+- Add origin/auth checks for WebSockets when exposed to browsers.
+- Keep `OXYROUTE_DEBUG` unset in production.
+- Use external storage for cross-worker state.
+
+## Known limitations in v0.3.0
+
+- Request bodies and multipart files are buffered in memory before parsing.
+- There is one pre-route middleware hook; compose middleware manually or with
+  helpers such as `apply_cors(..., chain=...)`.
+- There is no global exception-handler registry yet.
+- WebSocket subprotocol negotiation is not exposed as a high-level API.
+- Benchmark scripts are for local comparison and are not CI performance gates.
+
+## See also
+
+- [Routing](routing.md)
+- [Handlers](handlers.md)
+- [Dependencies](dependencies.md)
+- [CORS](cors.md)
+- [CSRF](csrf.md)
+- [JWT](jwt.md)
+- [WebSockets](websocket.md)
+- [RSGI and Granian](rsgi.md)

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -1,0 +1,100 @@
+# WebSockets (native RSGI)
+
+OxyRoute v0.3.0 ships a **native RSGI WebSocket** binding — the Granian
+[`RSGIWebsocketProtocol`](https://github.com/emmett-framework/granian/blob/master/granian/rsgi.py)
+is matched and dispatched directly inside the Rust `_oxyroute` extension. There is no ASGI
+bridge: the legacy `--interface asgi` WebSocket path was removed alongside the rest of the
+ASGI shim.
+
+## Quick start
+
+```python
+from oxyroute import App, WebSocket
+
+app = App()
+
+
+@app.websocket("/ws/:room")
+async def chat(ws: WebSocket) -> None:
+    await ws.accept()
+    room = ws.path_params["room"]
+    await ws.send_text(f"hello, {room}")
+    while True:
+        msg = await ws.receive_text()
+        if msg == "bye":
+            break
+        await ws.send_text(f"echo:{msg}")
+    await ws.close()
+```
+
+Run it like any other OxyRoute app:
+
+```bash
+granian app:app --interface rsgi --host 127.0.0.1 --port 8000
+```
+
+## API
+
+`oxyroute.WebSocket` is a thin Rust pyclass exported by the native module.
+
+| Member | Kind | Description |
+|---|---|---|
+| `scope` | property | The Granian RSGI scope (`proto == "websocket"`). |
+| `path_params` | property | `dict[str, str]` of path parameters extracted by the router. |
+| `is_closed` | property | `True` once `close()` has run or the peer disconnected. |
+| `await ws.accept()` | coroutine | Performs the handshake; required before send/receive. |
+| `await ws.receive()` | coroutine | Returns the next frame as `str` **or** `bytes`. Raises `RuntimeError` if the peer closed. |
+| `await ws.receive_text()` | coroutine | Like `receive`, but raises `ValueError` on a binary frame. |
+| `await ws.receive_bytes()` | coroutine | Like `receive`, but raises `ValueError` on a text frame. |
+| `await ws.send_text(s)` | coroutine | Send a text frame. |
+| `await ws.send_bytes(b)` | coroutine | Send a binary frame. |
+| `await ws.send_json(obj)` | coroutine | `json.dumps(obj)` then `send_text`. |
+| `await ws.close(code=None)` | coroutine | Close the connection (defaults to 1000). Idempotent. |
+
+Sync handlers are accepted by `@app.websocket(path)` for symmetry but should generally be
+async — Granian dispatches WebSockets on its event loop and most useful patterns require
+`await`.
+
+## Routing semantics
+
+* WebSocket routes live in their own `matchit::Router`. They never collide with HTTP routes,
+  so `GET /ws/:room` and `WS /ws/:room` can coexist.
+* Path syntax mirrors HTTP routes: `/ws/:room`, `/ws/:room/*rest`. Captured params are
+  available via `ws.path_params`.
+* Unknown WebSocket paths trigger a polite `protocol.close(1000)` (no 404 — close codes are
+  the WebSocket equivalent).
+* Calling `app.freeze()` locks WebSocket route registration the same way it locks HTTP
+  routes; further `@app.websocket(...)` raises `ValueError`.
+
+## Error handling
+
+* If the handler raises before completing, OxyRoute logs the error and calls
+  `protocol.close(1011)` (server-side error). The peer sees a clean close, never an open
+  connection that hangs.
+* If the **peer** closes (Granian sends `WebsocketMessageType.close`, kind `0`), the next
+  `receive*` raises `RuntimeError("WebSocket closed by peer")` and `ws.is_closed` becomes
+  `True`. A subsequent `await ws.close()` is a no-op (no double close).
+
+## Testing
+
+Drive the dispatcher in-process with mocked Granian-style scope/protocol/transport
+objects — see [`tests/test_websocket_native.py`](../tests/test_websocket_native.py) for a
+worked example. The pattern:
+
+1. Build an `_WSScope` dataclass with `proto = "websocket"`, the request `path`, etc.
+2. Build a mock `protocol` with an `async accept()` returning a transport, a
+   `close(status)` setter, and the transport's `async receive() / send_str / send_bytes`.
+3. Run `await app.handle_rsgi(scope, protocol)` from inside `asyncio.run(...)`.
+
+For end-to-end coverage with a real Granian server use a subprocess test similar to
+[`tests/test_granian_e2e.py`](../tests/test_granian_e2e.py), connecting with a real
+WebSocket client (e.g. `websockets`).
+
+## Migration from the previous ASGI WebSocket spike
+
+The pre-v0.3.0 ASGI WebSocket helper was removed. If you were using it:
+
+* Replace `from oxyroute.asgi import WebSocket` with `from oxyroute import WebSocket`.
+* Drop any `--interface asgi` Granian command lines — OxyRoute is RSGI-only.
+* `await ws.accept(subprotocol="…")` no longer accepts subprotocols (Granian's RSGI
+  WebSocket handshake selects them via headers; document that explicitly if you need it).

--- a/oxyroute/__init__.py
+++ b/oxyroute/__init__.py
@@ -1,6 +1,6 @@
 # Native extension first — prevents circular import with `app` importing `_oxyroute`.
 import oxyroute._oxyroute  # noqa: F401
-from oxyroute._oxyroute import decode_jwt_hs
+from oxyroute._oxyroute import WebSocket, decode_jwt_hs
 from oxyroute.app import App, Depends
 from oxyroute.cors import CORSConfig, apply_cors
 from oxyroute.csrf import CSRFConfig, apply_csrf, csrf_layer
@@ -20,6 +20,7 @@ __all__ = [
     "Response",
     "SSEEvent",
     "SecurityHeadersConfig",
+    "WebSocket",
     "__version__",
     "apply_cors",
     "apply_csrf",

--- a/oxyroute/app.py
+++ b/oxyroute/app.py
@@ -268,6 +268,24 @@ class App:
             jwt_cookie=jwt_cookie,
         )
 
+    def websocket(self, path: str) -> Callable[[F], F]:
+        """
+        Register a native RSGI WebSocket handler.
+
+        ``path`` uses the same ``matchit`` syntax as HTTP routes (e.g. ``/ws/:room``).
+        The handler receives a single :class:`oxyroute.WebSocket` argument; ``await``
+        :meth:`oxyroute.WebSocket.accept` once before sending or receiving frames.
+
+        Sync handlers run inline (the Rust dispatcher does not bridge them through Tokio
+        twice); async handlers are awaited on Granian's loop.
+        """
+
+        def wrap(handler: F) -> F:
+            self._app.add_websocket_route(path, handler)
+            return handler
+
+        return wrap
+
     def options(
         self,
         path: str,

--- a/oxyroute/app.py
+++ b/oxyroute/app.py
@@ -376,8 +376,15 @@ class App:
         """RSGI worker teardown (no-op in the base class)."""
         return None
 
-    async def __rsgi__(self, scope: Any, protocol: Any) -> None:
-        return await self._app.handle_rsgi(scope, protocol)
+    async def __rsgi__(self, scope: Any, protocol: Any) -> Any:
+        """
+        Granian awaits this coroutine. Native ``handle_rsgi`` may return ``None`` immediately
+        (sync short-circuit for openapi / 404 / 405) or an awaitable (full async path).
+        """
+        r = self._app.handle_rsgi(scope, protocol)
+        if r is None or not inspect.isawaitable(r):
+            return r
+        return await r
 
     def handle_rsgi(self, scope: Any, protocol: Any) -> Any:
         """Forward to the native ``handle_rsgi`` coroutine."""

--- a/perf-test/README.md
+++ b/perf-test/README.md
@@ -45,11 +45,14 @@ Run these from the **repository root** (the directory that contains `pyproject.t
 
 ```bash
 cd /path/to/OxyRoute
+# Include both `dev` and `bench` — `uv sync --extra bench` alone drops the `dev` group (pytest, ruff, …).
 uv sync --extra dev --extra bench
 # or: uv sync --all-extras
 # or: uv pip install -e ".[bench]"
 # wrk: sudo apt install wrk  /  brew install wrk
 ```
+
+`bench_hello.sh` uses `REPO/.venv/bin/python` when present so it does not fall back to **system** `python3` (where FastAPI is usually missing). Override with `PYTHON=/path/to/python` if needed.
 
 ## Run (`bench_hello.sh`)
 

--- a/perf-test/README.md
+++ b/perf-test/README.md
@@ -39,11 +39,33 @@ Minimal comparison on `GET /` returning plain text, both served by
 - OxyRoute: `--interface rsgi`
 - FastAPI: `--interface asgi`
 
+## Setup
+
+Run these from the **repository root** (the directory that contains `pyproject.toml`). If you `cd perf-test` first, editable installs and `uv sync` must still be run from the parent, or use `uv pip install -e "..[bench]"`.
+
 ```bash
 cd /path/to/OxyRoute
-uv sync --all-extras
+uv sync --extra dev --extra bench
+# or: uv sync --all-extras
+# or: uv pip install -e ".[bench]"
+# wrk: sudo apt install wrk  /  brew install wrk
+```
+
+## Run (`bench_hello.sh`)
+
+From the repository root:
+
+```bash
 ./perf-test/bench_hello.sh
 ```
+
+From inside `perf-test/` (same effect):
+
+```bash
+bash bench_hello.sh
+```
+
+(Ensure the venv has `oxyroute` and `fastapi`— simplest is to stay at repo root and use the paths above.)
 
 Optional environment knobs for `bench_hello.sh`:
 

--- a/perf-test/README.md
+++ b/perf-test/README.md
@@ -21,7 +21,7 @@ Both return plain text `hello world` to keep payloads equivalent.
 - Load profile: `wrk -t4 -c128 -d15s`
 - Repetitions: `3`
 
-## Run
+## Run (full compare)
 
 From repository root:
 
@@ -30,3 +30,36 @@ bash perf-test/bench.sh
 ```
 
 The script prints per-run metrics plus average/median RPS and relative delta.
+
+## Hello-world RPS (OxyRoute vs FastAPI)
+
+Minimal comparison on `GET /` returning plain text, both served by
+[Granian](https://github.com/emmett-framework/granian):
+
+- OxyRoute: `--interface rsgi`
+- FastAPI: `--interface asgi`
+
+```bash
+cd /path/to/OxyRoute
+uv sync --all-extras
+./perf-test/bench_hello.sh
+```
+
+Optional environment knobs for `bench_hello.sh`:
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `OXYROUTE_BENCH_DURATION` | `5s` | `wrk -d` |
+| `OXYROUTE_BENCH_THREADS` | `2` | `wrk -t` |
+| `OXYROUTE_BENCH_CONNECTIONS` | `32` | `wrk -c` |
+| `OXYROUTE_BENCH_WORKERS` | `1` | Granian `--workers` |
+
+## Optional pytest (short run)
+
+With `wrk` and `fastapi` available:
+
+```bash
+OXYROUTE_BENCH=1 uv run pytest tests/test_perf_hello_bench.py -m bench -v
+```
+
+By default the bench test is skipped (no load on normal `pytest`).

--- a/perf-test/app_fastapi.py
+++ b/perf-test/app_fastapi.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 
 app = FastAPI()
 
 
-@app.get("/")
+@app.get("/", response_class=PlainTextResponse)
 def root() -> str:
     return "hello"

--- a/perf-test/app_fastapi.py
+++ b/perf-test/app_fastapi.py
@@ -1,0 +1,12 @@
+"""Minimal FastAPI hello-world for `bench_hello.sh` (ASGI under Granian)."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def root() -> str:
+    return "hello"

--- a/perf-test/app_oxyroute.py
+++ b/perf-test/app_oxyroute.py
@@ -1,0 +1,12 @@
+"""Minimal OxyRoute hello-world for `bench_hello.sh` (RSGI)."""
+
+from __future__ import annotations
+
+from oxyroute import App
+
+app = App()
+
+
+@app.get("/")
+def root() -> str:
+    return "hello"

--- a/perf-test/bench.sh
+++ b/perf-test/bench.sh
@@ -5,21 +5,56 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
 HOST="127.0.0.1"
-PORT="8000"
-WRK_THREADS="4"
-WRK_CONN="128"
-WRK_DUR="15s"
-RUNS="3"
-SERVER_FLAGS=(--workers 2 --runtime-mode mt --runtime-threads 1)
+WRK_THREADS="${OXYROUTE_BENCH_THREADS:-4}"
+WRK_CONN="${OXYROUTE_BENCH_CONNECTIONS:-128}"
+WRK_DUR="${OXYROUTE_BENCH_DURATION:-15s}"
+RUNS="${OXYROUTE_BENCH_RUNS:-3}"
+WORKERS="${OXYROUTE_BENCH_WORKERS:-2}"
+RUNTIME_MODE="${OXYROUTE_BENCH_RUNTIME_MODE:-mt}"
+RUNTIME_THREADS="${OXYROUTE_BENCH_RUNTIME_THREADS:-1}"
+SERVER_FLAGS=(--workers "${WORKERS}" --runtime-mode "${RUNTIME_MODE}" --runtime-threads "${RUNTIME_THREADS}")
+BENCH_TMP="$(mktemp -d)"
+
+# Prefer the repo venv so OxyRoute / Granian / FastAPI all come from the same environment.
+if [[ -n "${PYTHON:-}" ]]; then
+  :
+elif [[ -x "${ROOT_DIR}/.venv/bin/python" ]]; then
+  PYTHON="${ROOT_DIR}/.venv/bin/python"
+else
+  PYTHON="python3"
+fi
 
 cleanup() {
   if [[ -n "${SERVER_PID:-}" ]]; then
-    kill "${SERVER_PID}" 2>/dev/null || true
+    # Servers are launched in their own process group; kill the group so Granian workers do not
+    # survive after the wrapper exits (the main source of polluted follow-up runs).
+    kill -- "-${SERVER_PID}" 2>/dev/null || kill "${SERVER_PID}" 2>/dev/null || true
     wait "${SERVER_PID}" 2>/dev/null || true
     SERVER_PID=""
   fi
 }
-trap cleanup EXIT
+
+final_cleanup() {
+  cleanup
+  rm -rf "${BENCH_TMP}"
+}
+trap final_cleanup EXIT
+
+free_port() {
+  "${PYTHON}" -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', 0)); print(s.getsockname()[1]); s.close()"
+}
+
+wait_http() {
+  local port="$1"
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if "${PYTHON}" -c "import urllib.request; urllib.request.urlopen('http://${HOST}:${port}/', timeout=0.5).read()" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
 
 extract_rps() {
   awk '/Requests\/sec:/ {print $2}' "$1"
@@ -31,19 +66,33 @@ extract_latency() {
 
 run_suite() {
   local name="$1"
-  local start_cmd="$2"
-  local out_prefix="$3"
+  local module_path="$2"
+  local interface="$3"
+  local out_prefix="$4"
+  local port
+  port="$(free_port)"
+  local -a cmd=(
+    "${PYTHON}" -m granian "${module_path}"
+    --interface "${interface}"
+    --host "${HOST}"
+    --port "${port}"
+    "${SERVER_FLAGS[@]}"
+  )
 
   echo "=== ${name} ==="
-  eval "${start_cmd}" >/tmp/"${out_prefix}"_server.log 2>&1 &
+  setsid "${cmd[@]}" >"${BENCH_TMP}/${out_prefix}_server.log" 2>&1 &
   SERVER_PID=$!
-  sleep 2
-  curl -fsS "http://${HOST}:${PORT}/" >/tmp/"${out_prefix}"_smoke.txt
+  if ! wait_http "${port}"; then
+    echo "error: server did not become ready (${name})" >&2
+    echo "--- server log ---" >&2
+    sed -n '1,120p' "${BENCH_TMP}/${out_prefix}_server.log" >&2 || true
+    exit 1
+  fi
 
   local rps_values=()
   for i in $(seq 1 "${RUNS}"); do
-    local out_file="/tmp/${out_prefix}_wrk_${i}.txt"
-    wrk -t"${WRK_THREADS}" -c"${WRK_CONN}" -d"${WRK_DUR}" "http://${HOST}:${PORT}/" | tee "${out_file}" >/dev/null
+    local out_file="${BENCH_TMP}/${out_prefix}_wrk_${i}.txt"
+    wrk -t"${WRK_THREADS}" -c"${WRK_CONN}" -d"${WRK_DUR}" "http://${HOST}:${port}/" | tee "${out_file}" >/dev/null
     local rps
     rps="$(extract_rps "${out_file}")"
     local lat
@@ -54,7 +103,7 @@ run_suite() {
 
   cleanup
 
-  python3 - "$name" "${rps_values[@]}" <<'PY'
+  "${PYTHON}" - "$name" "${rps_values[@]}" <<'PY'
 import statistics
 import sys
 name = sys.argv[1]
@@ -65,35 +114,49 @@ PY
 
 run_suite \
   "OxyRoute RSGI (tuned)" \
-  "granian perf-test.app:app --interface rsgi --host ${HOST} --port ${PORT} ${SERVER_FLAGS[*]}" \
+  "perf-test.app:app" \
+  "rsgi" \
   "oxyroute"
+
+if ! "${PYTHON}" -c "import fastapi" 2>/dev/null; then
+  echo "FastAPI not installed. From the repo root: uv sync --extra dev --extra bench" >&2
+  exit 0
+fi
 
 run_suite \
   "FastAPI ASGI (tuned)" \
-  "uv run --with fastapi granian perf-test.fastapi_app:app --interface asgi --host ${HOST} --port ${PORT} ${SERVER_FLAGS[*]}" \
+  "perf-test.fastapi_app:app" \
+  "asgi" \
   "fastapi"
 
-python3 - <<'PY'
+"${PYTHON}" - "${BENCH_TMP}" <<'PY'
 import glob
 import statistics
+import sys
+
+tmp = sys.argv[1]
 
 def read_rps(prefix):
     vals = []
-    for p in sorted(glob.glob(f"/tmp/{prefix}_wrk_*.txt")):
+    for p in sorted(glob.glob(f"{tmp}/{prefix}_wrk_*.txt")):
         with open(p, "r", encoding="utf-8") as f:
             for line in f:
-                if line.startswith("Requests/sec:"):
+                if "Requests/sec:" in line:
                     vals.append(float(line.split()[-1]))
                     break
     return vals
 
 oxy = read_rps("oxyroute")
 fa = read_rps("fastapi")
+if not oxy or not fa:
+    raise SystemExit(f"missing wrk results: oxyroute={oxy!r}, fastapi={fa!r}")
 oxy_avg = sum(oxy)/len(oxy)
 fa_avg = sum(fa)/len(fa)
-delta = (oxy_avg / fa_avg - 1.0) * 100.0
+ratio = oxy_avg / fa_avg
+uplift = (ratio - 1.0) * 100.0
 print("=== Summary ===")
 print(f"OxyRoute avg={oxy_avg:.2f} median={statistics.median(oxy):.2f}")
 print(f"FastAPI avg={fa_avg:.2f} median={statistics.median(fa):.2f}")
-print(f"Delta (OxyRoute vs FastAPI): {delta:+.2f}%")
+print(f"Ratio (OxyRoute / FastAPI): {ratio:.2f}x")
+print(f"Relative uplift vs FastAPI: {uplift:+.2f}%")
 PY

--- a/perf-test/bench_hello.sh
+++ b/perf-test/bench_hello.sh
@@ -87,16 +87,16 @@ main() {
   fi
   fa=$(_bench "fastapi" "app_fastapi:app" "asgi")
 
-  local pct
-  pct=$("${PYTHON}" -c "o=float('${oxy}'); f=float('${fa}');
+  local stats
+  stats=$("${PYTHON}" -c "o=float('${oxy}'); f=float('${fa}');
 if f <= 0:
-  print('n/a')
+  print('ratio=n/a uplift=n/a')
 else:
-  print(f'{(o/f-1.0)*100.0:+.2f}')")
+  print(f'ratio={o/f:.2f}x uplift={(o/f-1.0)*100.0:+.2f}%')")
 
   echo "OxyRoute  RSGI  Requests/sec: ${oxy}"
   echo "FastAPI   ASGI  Requests/sec: ${fa}"
-  echo "Delta (OxyRoute vs FastAPI): ${pct}%"
+  echo "Ratio / Relative uplift: ${stats}"
 }
 
 main "$@"

--- a/perf-test/bench_hello.sh
+++ b/perf-test/bench_hello.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Compare OxyRoute (RSGI) vs FastAPI (ASGI) on a plain "hello" GET / using wrk.
+# Requirements: granian, wrk, optional: `uv pip install -e ".[bench]"` for FastAPI.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+DURATION="${OXYROUTE_BENCH_DURATION:-5s}"
+THREADS="${OXYROUTE_BENCH_THREADS:-2}"
+CONN="${OXYROUTE_BENCH_CONNECTIONS:-32}"
+WORKERS="${OXYROUTE_BENCH_WORKERS:-1}"
+
+if ! command -v wrk >/dev/null 2>&1; then
+  echo "error: wrk not found (install wrk and retry)" >&2
+  exit 1
+fi
+
+_free_port() {
+  python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1]); s.close()"
+}
+
+_run_wrk() {
+  local url="$1"
+  wrk -t"${THREADS}" -c"${CONN}" -d"${DURATION}" "${url}" 2>&1 \
+    | awk '/Requests\/sec:/{gsub(/^[ \t]+/,"",$2); print $2; exit}'
+}
+
+_wait_http() {
+  local port="$1"
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${port}/', timeout=0.5).read()" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+_bench() {
+  local name="$1" module_path="$2" iface="$3" port
+  port="$(_free_port)"
+  local -a cmd=(python3 -m granian "${module_path}" --host 127.0.0.1 --port "${port}" --interface "${iface}" --workers "${WORKERS}")
+  # Silence server logs so command substitution only captures the numeric RPS line.
+  (
+    export PYTHONPATH="${ROOT}"
+    cd "${ROOT}/perf-test"
+    exec "${cmd[@]}"
+  ) >/dev/null 2>&1 &
+  local pid=$!
+  if ! _wait_http "${port}"; then
+    kill "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+    echo "error: server did not become ready (${name})" >&2
+    exit 1
+  fi
+  local rps
+  rps=$(_run_wrk "http://127.0.0.1:${port}/")
+  kill "${pid}" 2>/dev/null || true
+  wait "${pid}" 2>/dev/null || true
+  echo "${rps}"
+}
+
+main() {
+  echo "bench_hello: OxyRoute (rsgi) vs FastAPI (asgi)"
+  echo "  duration=${DURATION} threads=${THREADS} connections=${CONN} workers=${WORKERS}"
+  echo ""
+
+  local oxy
+  oxy=$(_bench "oxyroute" "app_oxyroute:app" "rsgi")
+  local fa
+  if ! python3 -c "import fastapi" 2>/dev/null; then
+    echo "FastAPI not installed; install with: uv pip install -e \".[bench]\""
+    echo "OxyRoute Requests/sec: ${oxy}"
+    exit 0
+  fi
+  fa=$(_bench "fastapi" "app_fastapi:app" "asgi")
+
+  local pct
+  pct=$(python3 -c "o=float('${oxy}'); f=float('${fa}');
+if f <= 0:
+  print('n/a')
+else:
+  print(f'{(o/f-1.0)*100.0:+.2f}')")
+
+  echo "OxyRoute  RSGI  Requests/sec: ${oxy}"
+  echo "FastAPI   ASGI  Requests/sec: ${fa}"
+  echo "Delta (OxyRoute vs FastAPI): ${pct}%"
+}
+
+main "$@"

--- a/perf-test/bench_hello.sh
+++ b/perf-test/bench_hello.sh
@@ -6,6 +6,16 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+# Prefer the repo `.venv` interpreter so Granian / FastAPI match `uv sync` results.
+# Plain `python3` is often the system Python and does not see bench extras.
+if [[ -n "${PYTHON:-}" ]]; then
+  :
+elif [[ -x "${ROOT}/.venv/bin/python" ]]; then
+  PYTHON="${ROOT}/.venv/bin/python"
+else
+  PYTHON="python3"
+fi
+
 DURATION="${OXYROUTE_BENCH_DURATION:-5s}"
 THREADS="${OXYROUTE_BENCH_THREADS:-2}"
 CONN="${OXYROUTE_BENCH_CONNECTIONS:-32}"
@@ -17,7 +27,7 @@ if ! command -v wrk >/dev/null 2>&1; then
 fi
 
 _free_port() {
-  python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1]); s.close()"
+  "${PYTHON}" -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1]); s.close()"
 }
 
 _run_wrk() {
@@ -30,7 +40,7 @@ _wait_http() {
   local port="$1"
   local deadline=$((SECONDS + 30))
   while (( SECONDS < deadline )); do
-    if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${port}/', timeout=0.5).read()" 2>/dev/null; then
+    if "${PYTHON}" -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${port}/', timeout=0.5).read()" 2>/dev/null; then
       return 0
     fi
     sleep 0.05
@@ -41,7 +51,7 @@ _wait_http() {
 _bench() {
   local name="$1" module_path="$2" iface="$3" port
   port="$(_free_port)"
-  local -a cmd=(python3 -m granian "${module_path}" --host 127.0.0.1 --port "${port}" --interface "${iface}" --workers "${WORKERS}")
+  local -a cmd=("${PYTHON}" -m granian "${module_path}" --host 127.0.0.1 --port "${port}" --interface "${iface}" --workers "${WORKERS}")
   # Silence server logs so command substitution only captures the numeric RPS line.
   (
     export PYTHONPATH="${ROOT}"
@@ -70,15 +80,15 @@ main() {
   local oxy
   oxy=$(_bench "oxyroute" "app_oxyroute:app" "rsgi")
   local fa
-  if ! python3 -c "import fastapi" 2>/dev/null; then
-    echo "FastAPI not installed. From the repo root: uv sync --extra bench  (or uv pip install -e \".[bench]\")" >&2
+  if ! "${PYTHON}" -c "import fastapi" 2>/dev/null; then
+    echo "FastAPI not installed. From the repo root: uv sync --extra dev --extra bench" >&2
     echo "OxyRoute Requests/sec: ${oxy}"
     exit 0
   fi
   fa=$(_bench "fastapi" "app_fastapi:app" "asgi")
 
   local pct
-  pct=$(python3 -c "o=float('${oxy}'); f=float('${fa}');
+  pct=$("${PYTHON}" -c "o=float('${oxy}'); f=float('${fa}');
 if f <= 0:
   print('n/a')
 else:

--- a/perf-test/bench_hello.sh
+++ b/perf-test/bench_hello.sh
@@ -71,7 +71,7 @@ main() {
   oxy=$(_bench "oxyroute" "app_oxyroute:app" "rsgi")
   local fa
   if ! python3 -c "import fastapi" 2>/dev/null; then
-    echo "FastAPI not installed; install with: uv pip install -e \".[bench]\""
+    echo "FastAPI not installed. From the repo root: uv sync --extra bench  (or uv pip install -e \".[bench]\")" >&2
     echo "OxyRoute Requests/sec: ${oxy}"
     exit 0
   fi

--- a/perf-test/fastapi_app.py
+++ b/perf-test/fastapi_app.py
@@ -1,8 +1,9 @@
 from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 
 app = FastAPI(title="Perf Test FastAPI")
 
 
-@app.get("/")
+@app.get("/", response_class=PlainTextResponse)
 def hello() -> str:
     return "hello world"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,21 @@ dev = [
     "cryptography>=42",
     "ruff>=0.8",
 ]
+# Hello-world RPS compare vs FastAPI (see perf-test/bench_hello.sh); not required for library use.
+bench = [
+    "fastapi>=0.100",
+    "granian>=1.0",
+    "httpx>=0.27",
+]
 
 [tool.maturin]
 module-name = "oxyroute._oxyroute"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "bench: optional wrk load test; run with OXYROUTE_BENCH=1 and pip install -e .[bench]",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -13,31 +13,14 @@ use crate::form::{self, ParsedFile};
 use crate::params::{build_request_context, header_get_lax, parse_query, value_for_path_param};
 use crate::response;
 use crate::schema::json_to_py;
-use crate::state::{match_route, match_ws_route, methods_matching_path, AppState};
+use crate::state::{
+    match_route_compiled, match_ws_route_compiled, methods_matching_path_compiled, AppState,
+    CompiledRouters, HotSnapshot, RouteEntry,
+};
 use crate::token::{build_decoding_key, extract_bearer, extract_cookie_value};
 use crate::websocket::WebSocket;
 
 type HttpExceptionPayload = (u16, Vec<u8>, Vec<(String, String)>);
-
-type RouteCallSnapshot = (
-    Py<PyAny>,
-    bool,
-    bool,
-    Option<String>,
-    Arc<[jsonwebtoken::Algorithm]>,
-    Option<String>,
-    Option<String>,
-    u64,
-    Option<String>,
-    bool, // read_json_body
-    bool, // read_form_body
-    Arc<[String]>,
-    Arc<[Py<PyAny>]>,
-    Arc<[bool]>,
-    Arc<[bool]>,
-    Arc<HashSet<String>>,
-    bool,
-);
 
 fn oxyroute_debug() -> bool {
     std::env::var("OXYROUTE_DEBUG")
@@ -146,15 +129,17 @@ async fn send_python_error(
     send_internal_error(protocol, method, path, err).await
 }
 
-fn ensure_compiled_snapshot(state: &Arc<RwLock<AppState>>) {
-    if state.read().compiled.is_some() {
-        return;
+fn ensure_compiled_snapshot(state: &Arc<RwLock<AppState>>) -> Arc<CompiledRouters> {
+    if let Some(c) = state.read().compiled.as_ref() {
+        return Arc::clone(c);
     }
     let mut st = state.write();
     if st.compiled.is_none() {
         st.compiled = Some(Arc::new(st.snapshot_routers()));
     }
+    Arc::clone(st.compiled.as_ref().expect("just populated"))
 }
+
 
 /// Synchronous RSGI handling for **openapi**, **404**, and **405** only: no `protocol()` body read
 /// and no `future_into_py` outer bridge (saves a Tokio task + asyncio Future on these paths).
@@ -177,57 +162,49 @@ pub fn try_rsgi_sync_short_circuit(
     let method: String = scope.getattr("method")?.extract()?;
     let path: String = scope.getattr("path")?.extract()?;
     let is_head = method == "HEAD";
-    if (method == "GET" || method == "HEAD") && path == "/openapi.json" {
-        let (inc, doc) = {
-            let st = state.read();
-            if !st.include_openapi {
-                (false, String::new())
-            } else {
-                let oa = st.openapi.lock();
-                (true, oa.to_string())
-            }
-        };
-        if inc {
-            if is_head {
-                response::send_head_simple_sync(
-                    py,
-                    &protocol_py,
-                    200,
-                    doc.len(),
-                    "application/json; charset=utf-8",
-                )?;
-            } else {
-                response::send_str_sync(
-                    py,
-                    &protocol_py,
-                    200,
-                    &doc,
-                    "application/json; charset=utf-8",
-                )?;
-            }
-            return Ok(Some(py.None()));
-        }
-    }
-    if state.read().middleware.is_some() {
+    let snapshot = state.read().hot_snapshot();
+    if snapshot.middleware.is_some() {
         return Ok(None);
     }
-    ensure_compiled_snapshot(state);
-    let route_out: Option<(usize, HashMap<String, String>)> = {
-        let st = state.read();
-        match match_route(&st, &method, &path) {
-            None => {
-                return Err(pyo3::exceptions::PyValueError::new_err("method"));
-            }
-            Some(m) => m,
+    if (method == "GET" || method == "HEAD") && path == "/openapi.json" && snapshot.include_openapi
+    {
+        let doc = state.read().openapi.lock().to_string();
+        if is_head {
+            response::send_head_simple_sync(
+                py,
+                &protocol_py,
+                200,
+                doc.len(),
+                "application/json; charset=utf-8",
+            )?;
+        } else {
+            response::send_str_sync(
+                py,
+                &protocol_py,
+                200,
+                &doc,
+                "application/json; charset=utf-8",
+            )?;
         }
+        return Ok(Some(py.None()));
+    }
+    // Build the compiled snapshot if it has not been promoted yet. Safe under GIL: only the
+    // current thread is in Rust, the prelim read guard above has been dropped, and parking_lot
+    // is non-reentrant — no scenario where this write blocks the same thread.
+    let compiled = match snapshot.compiled.clone() {
+        Some(c) => c,
+        None => ensure_compiled_snapshot(state),
+    };
+    let route_out = match match_route_compiled(&compiled, &method, &path) {
+        None => {
+            return Err(pyo3::exceptions::PyValueError::new_err("method"));
+        }
+        Some(m) => m,
     };
     match route_out {
         Some((_, _)) => Ok(None),
         None => {
-            let m = {
-                let st = state.read();
-                methods_matching_path(&st, &path)
-            };
+            let m = methods_matching_path_compiled(&compiled, &path);
             if m.is_empty() {
                 response::send_text_sync(
                     py,
@@ -251,15 +228,7 @@ pub async fn run_rsgi(
 ) -> PyResult<PyObject> {
     // Single GIL block: read proto, scope fields, and shared cfg in one acquire/release.
     // Each `Python::with_gil` costs ~100-300ns; coalescing saves ~1µs/req on the http path.
-    type RsgiPrelim = (
-        String,
-        String,
-        String,
-        bool,
-        Option<Py<PyAny>>,
-        Option<Py<PyAny>>,
-        Option<Py<PyAny>>,
-    );
+    type RsgiPrelim = (String, String, String, bool, HotSnapshot);
     let (proto, prelim): (String, Option<RsgiPrelim>) = Python::with_gil(|py| -> PyResult<_> {
         let s = scope.bind(py);
         let proto: String = s.getattr("proto")?.extract()?;
@@ -276,50 +245,39 @@ pub async fn run_rsgi(
             .and_then(|x| x.extract())
             .unwrap_or_default();
         let is_head = method == "HEAD";
-        let st = state.read();
-        Ok((
-            proto,
-            Some((
-                method,
-                path,
-                qs,
-                is_head,
-                st.cors.clone(),
-                st.security_headers.clone(),
-                st.middleware.clone(),
-            )),
-        ))
+        // One `state.read()` for the entire request: every subsequent dispatch step uses
+        // [`HotSnapshot`] without re-acquiring the `RwLock`. The snapshot's
+        // ``Option<Py<PyAny>>`` fields are cloned *here*, while the GIL is held.
+        let snapshot = state.read().hot_snapshot();
+        Ok((proto, Some((method, path, qs, is_head, snapshot))))
     })?;
     if proto == "websocket" {
         return run_rsgi_websocket(state, scope, protocol).await;
     }
-    let Some((method, path, query_string, is_head, cors_cfg, security_cfg, maybe_mw)) = prelim
-    else {
+    let Some((method, path, query_string, is_head, snapshot)) = prelim else {
         return Ok(Python::with_gil(|py| py.None()));
     };
-    if (method == "GET" || method == "HEAD") && path == "/openapi.json" {
-        let (inc, doc) = {
-            let st = state.read();
-            if !st.include_openapi {
-                (false, String::new())
-            } else {
-                let oa = st.openapi.lock();
-                (true, oa.to_string())
-            }
-        };
-        if inc {
-            if is_head {
-                return response::send_head_simple(
-                    &protocol,
-                    200,
-                    doc.len(),
-                    "application/json; charset=utf-8",
-                )
-                .await;
-            }
-            return response::send_str(&protocol, 200, &doc, "application/json; charset=utf-8")
-                .await;
+    type CfgClones = (Option<Py<PyAny>>, Option<Py<PyAny>>, Option<Py<PyAny>>);
+    let (cors_cfg, security_cfg, maybe_mw): CfgClones = Python::with_gil(|_py| {
+        (
+            snapshot.cors.clone(),
+            snapshot.security_headers.clone(),
+            snapshot.middleware.clone(),
+        )
+    });
+    if (method == "GET" || method == "HEAD") && path == "/openapi.json" && snapshot.include_openapi
+    {
+        let doc = state.read().openapi.lock().to_string();
+        if is_head {
+            return response::send_head_simple(
+                &protocol,
+                200,
+                doc.len(),
+                "application/json; charset=utf-8",
+            )
+            .await;
         }
+        return response::send_str(&protocol, 200, &doc, "application/json; charset=utf-8").await;
     }
     if let Some(mw) = maybe_mw {
         let out: Py<PyAny> = match Python::with_gil(|py| {
@@ -358,21 +316,18 @@ pub async fn run_rsgi(
     }
     // Auto-enable compiled route snapshot on first request to keep hot-path matching lock-free
     // even when users forget to call `freeze()` explicitly.
-    ensure_compiled_snapshot(&state);
-    let route_out: Option<(usize, HashMap<String, String>)> = {
-        let st = state.read();
-        match match_route(&st, &method, &path) {
-            None => Err(pyo3::exceptions::PyValueError::new_err("method")),
-            Some(m) => Ok(m),
-        }
+    let compiled = match snapshot.compiled.clone() {
+        Some(c) => c,
+        None => ensure_compiled_snapshot(&state),
+    };
+    let route_out = match match_route_compiled(&compiled, &method, &path) {
+        None => Err(pyo3::exceptions::PyValueError::new_err("method")),
+        Some(m) => Ok(m),
     }?;
     let (route_idx, param_map) = match route_out {
         Some(x) => x,
         None => {
-            let m = {
-                let st = state.read();
-                methods_matching_path(&st, &path)
-            };
+            let m = methods_matching_path_compiled(&compiled, &path);
             if m.is_empty() {
                 return response::send_text(
                     &protocol,
@@ -385,6 +340,8 @@ pub async fn run_rsgi(
             return response::send_405_method_not_allowed(&protocol, &m).await;
         }
     };
+    let routes_arc: Arc<Vec<RouteEntry>> = Arc::clone(&snapshot.routes);
+    // ``Py<PyAny>::clone`` is GIL-bound; do the route-entry destructure inside `with_gil`.
     let (
         handler,
         is_async,
@@ -403,10 +360,8 @@ pub async fn run_rsgi(
         dep_wants_request,
         handler_param_names,
         handler_varkw,
-    ) = Python::with_gil(|_py| -> PyResult<RouteCallSnapshot> {
-        let st = state.read();
-        let e = st
-            .routes
+    ) = Python::with_gil(|_py| -> PyResult<_> {
+        let e = routes_arc
             .get(route_idx)
             .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("route index"))?;
         Ok((
@@ -1263,11 +1218,13 @@ async fn run_rsgi_websocket(
 ) -> PyResult<PyObject> {
     let path: String =
         Python::with_gil(|py| -> PyResult<String> { scope.bind(py).getattr("path")?.extract() })?;
-    ensure_compiled_snapshot(&state);
-    let route_match = {
-        let st = state.read();
-        match_ws_route(&st, &path)
+    let snapshot = state.read().hot_snapshot();
+    let compiled = match snapshot.compiled.clone() {
+        Some(c) => c,
+        None => ensure_compiled_snapshot(&state),
     };
+    let ws_routes = Arc::clone(&snapshot.websocket_routes);
+    let route_match = match_ws_route_compiled(&compiled, &path);
     let Some((route_idx, param_map)) = route_match else {
         // No route → polite close. ``close`` is sync on RSGIWebsocketProtocol.
         let _ = Python::with_gil(|py| -> PyResult<()> {
@@ -1278,9 +1235,7 @@ async fn run_rsgi_websocket(
         return Ok(Python::with_gil(|py| py.None()));
     };
     let (handler, is_async) = Python::with_gil(|_py| -> PyResult<(Py<PyAny>, bool)> {
-        let st = state.read();
-        let e = st
-            .websocket_routes
+        let e = ws_routes
             .get(route_idx)
             .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("ws route index"))?;
         Ok((e.handler.clone(), e.is_async))

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -140,7 +140,6 @@ fn ensure_compiled_snapshot(state: &Arc<RwLock<AppState>>) -> Arc<CompiledRouter
     Arc::clone(st.compiled.as_ref().expect("just populated"))
 }
 
-
 /// Synchronous RSGI handling for **openapi**, **404**, and **405** only: no `protocol()` body read
 /// and no `future_into_py` outer bridge (saves a Tokio task + asyncio Future on these paths).
 ///

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -156,6 +156,94 @@ fn ensure_compiled_snapshot(state: &Arc<RwLock<AppState>>) {
     }
 }
 
+/// Synchronous RSGI handling for **openapi**, **404**, and **405** only: no `protocol()` body read
+/// and no `future_into_py` outer bridge (saves a Tokio task + asyncio Future on these paths).
+///
+/// Returns `Ok(None)` if [`run_rsgi`] (async) must be used. Middleware always defers to async.
+pub fn try_rsgi_sync_short_circuit(
+    py: Python<'_>,
+    state: &Arc<RwLock<AppState>>,
+    scope: &Bound<'_, PyAny>,
+    protocol: &Bound<'_, PyAny>,
+) -> PyResult<Option<PyObject>> {
+    let protocol_py: Py<PyAny> = protocol.as_any().clone().unbind();
+    let proto: String = scope.getattr("proto")?.extract()?;
+    if proto == "websocket" {
+        return Ok(None);
+    }
+    if proto != "http" {
+        return Ok(Some(py.None()));
+    }
+    let method: String = scope.getattr("method")?.extract()?;
+    let path: String = scope.getattr("path")?.extract()?;
+    let is_head = method == "HEAD";
+    if (method == "GET" || method == "HEAD") && path == "/openapi.json" {
+        let (inc, doc) = {
+            let st = state.read();
+            if !st.include_openapi {
+                (false, String::new())
+            } else {
+                let oa = st.openapi.lock();
+                (true, oa.to_string())
+            }
+        };
+        if inc {
+            if is_head {
+                response::send_head_simple_sync(
+                    py,
+                    &protocol_py,
+                    200,
+                    doc.len(),
+                    "application/json; charset=utf-8",
+                )?;
+            } else {
+                response::send_str_sync(
+                    py,
+                    &protocol_py,
+                    200,
+                    &doc,
+                    "application/json; charset=utf-8",
+                )?;
+            }
+            return Ok(Some(py.None()));
+        }
+    }
+    if state.read().middleware.is_some() {
+        return Ok(None);
+    }
+    ensure_compiled_snapshot(state);
+    let route_out: Option<(usize, HashMap<String, String>)> = {
+        let st = state.read();
+        match match_route(&st, &method, &path) {
+            None => {
+                return Err(pyo3::exceptions::PyValueError::new_err("method"));
+            }
+            Some(m) => m,
+        }
+    };
+    match route_out {
+        Some((_, _)) => Ok(None),
+        None => {
+            let m = {
+                let st = state.read();
+                methods_matching_path(&st, &path)
+            };
+            if m.is_empty() {
+                response::send_text_sync(
+                    py,
+                    &protocol_py,
+                    404,
+                    "Not Found",
+                    "text/plain; charset=utf-8",
+                )?;
+            } else {
+                response::send_405_method_not_allowed_sync(py, &protocol_py, &m)?;
+            }
+            Ok(Some(py.None()))
+        }
+    }
+}
+
 pub async fn run_rsgi(
     state: Arc<RwLock<AppState>>,
     scope: Py<PyAny>,
@@ -667,14 +755,15 @@ pub async fn run_rsgi(
             dep_out.push(o);
         }
     }
-    let should_pass_form = read_form_body && (handler_varkw || handler_param_names.contains("form"));
-    let should_pass_files = read_form_body && (handler_varkw || handler_param_names.contains("files"));
+    let should_pass_form =
+        read_form_body && (handler_varkw || handler_param_names.contains("form"));
+    let should_pass_files =
+        read_form_body && (handler_varkw || handler_param_names.contains("files"));
     let should_pass_protocol = handler_varkw || handler_param_names.contains("protocol");
     let should_pass_body = !read_form_body && !body_bytes.is_empty() && body_json.is_none();
-    let has_dep_kwargs = dep_names
-        .iter()
-        .enumerate()
-        .any(|(i, name)| dep_out.get(i).is_some() && (handler_varkw || handler_param_names.contains(name)));
+    let has_dep_kwargs = dep_names.iter().enumerate().any(|(i, name)| {
+        dep_out.get(i).is_some() && (handler_varkw || handler_param_names.contains(name))
+    });
     let should_use_kwargs = !param_map.is_empty()
         || !query_map.is_empty()
         || has_dep_kwargs
@@ -949,7 +1038,6 @@ fn send_handler_map_inline(
     }
 }
 
-
 /// `if_absent`: only add a header if no same-name (case-insensitive) header is already present
 /// (``security`` preset). `false` replaces/merges like CORS (``replace`` / duplicate header names).
 fn merge_config_response_headers(
@@ -1139,7 +1227,10 @@ fn value_to_bytes_and_ct(py: Python<'_>, b: &Bound<'_, PyAny>) -> PyResult<(Vec<
         ));
     }
     if let Ok(buf) = b.downcast::<PyBytes>() {
-        return Ok((buf.as_bytes().to_vec(), "application/octet-stream".to_string()));
+        return Ok((
+            buf.as_bytes().to_vec(),
+            "application/octet-stream".to_string(),
+        ));
     }
     if let Ok(s) = b.extract::<String>() {
         return Ok((s.into_bytes(), "text/plain; charset=utf-8".to_string()));

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -13,8 +13,9 @@ use crate::form::{self, ParsedFile};
 use crate::params::{build_request_context, header_get_lax, parse_query, value_for_path_param};
 use crate::response;
 use crate::schema::json_to_py;
-use crate::state::{match_route, methods_matching_path, AppState};
+use crate::state::{match_route, match_ws_route, methods_matching_path, AppState};
 use crate::token::{build_decoding_key, extract_bearer, extract_cookie_value};
+use crate::websocket::WebSocket;
 
 type HttpExceptionPayload = (u16, Vec<u8>, Vec<(String, String)>);
 
@@ -160,8 +161,8 @@ pub async fn run_rsgi(
     scope: Py<PyAny>,
     protocol: Py<PyAny>,
 ) -> PyResult<PyObject> {
-    // Single GIL block: read scope attributes + clone shared cfg refs in one acquire/release.
-    // Each `Python::with_gil` costs ~100-300ns; coalescing 5 separate blocks saves ~1µs/req.
+    // Single GIL block: read proto, scope fields, and shared cfg in one acquire/release.
+    // Each `Python::with_gil` costs ~100-300ns; coalescing saves ~1µs/req on the http path.
     type RsgiPrelim = (
         String,
         String,
@@ -171,11 +172,14 @@ pub async fn run_rsgi(
         Option<Py<PyAny>>,
         Option<Py<PyAny>>,
     );
-    let prelim: Option<RsgiPrelim> = Python::with_gil(|py| -> PyResult<Option<RsgiPrelim>> {
+    let (proto, prelim): (String, Option<RsgiPrelim>) = Python::with_gil(|py| -> PyResult<_> {
         let s = scope.bind(py);
         let proto: String = s.getattr("proto")?.extract()?;
+        if proto == "websocket" {
+            return Ok((proto, None::<RsgiPrelim>));
+        }
         if proto != "http" {
-            return Ok(None);
+            return Ok((proto, None::<RsgiPrelim>));
         }
         let method: String = s.getattr("method")?.extract()?;
         let path: String = s.getattr("path")?.extract()?;
@@ -185,16 +189,22 @@ pub async fn run_rsgi(
             .unwrap_or_default();
         let is_head = method == "HEAD";
         let st = state.read();
-        Ok(Some((
-            method,
-            path,
-            qs,
-            is_head,
-            st.cors.clone(),
-            st.security_headers.clone(),
-            st.middleware.clone(),
-        )))
+        Ok((
+            proto,
+            Some((
+                method,
+                path,
+                qs,
+                is_head,
+                st.cors.clone(),
+                st.security_headers.clone(),
+                st.middleware.clone(),
+            )),
+        ))
     })?;
+    if proto == "websocket" {
+        return run_rsgi_websocket(state, scope, protocol).await;
+    }
     let Some((method, path, query_string, is_head, cors_cfg, security_cfg, maybe_mw)) = prelim
     else {
         return Ok(Python::with_gil(|py| py.None()));
@@ -1150,4 +1160,79 @@ fn value_to_bytes_and_ct(py: Python<'_>, b: &Bound<'_, PyAny>) -> PyResult<(Vec<
         s.into_bytes(),
         "application/json; charset=utf-8".to_string(),
     ))
+}
+
+/// Dispatch a Granian RSGI WebSocket scope: match `path` in `AppState::websocket` and run
+/// the handler with a [`WebSocket`] helper. No matching route → ``protocol.close(1000)``;
+/// handler error → close (best-effort) and propagate to logs.
+async fn run_rsgi_websocket(
+    state: Arc<RwLock<AppState>>,
+    scope: Py<PyAny>,
+    protocol: Py<PyAny>,
+) -> PyResult<PyObject> {
+    let path: String =
+        Python::with_gil(|py| -> PyResult<String> { scope.bind(py).getattr("path")?.extract() })?;
+    ensure_compiled_snapshot(&state);
+    let route_match = {
+        let st = state.read();
+        match_ws_route(&st, &path)
+    };
+    let Some((route_idx, param_map)) = route_match else {
+        // No route → polite close. ``close`` is sync on RSGIWebsocketProtocol.
+        let _ = Python::with_gil(|py| -> PyResult<()> {
+            let p = protocol.bind(py);
+            let _ = p.call_method1("close", (1000i32,));
+            Ok(())
+        });
+        return Ok(Python::with_gil(|py| py.None()));
+    };
+    let (handler, is_async) = Python::with_gil(|_py| -> PyResult<(Py<PyAny>, bool)> {
+        let st = state.read();
+        let e = st
+            .websocket_routes
+            .get(route_idx)
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("ws route index"))?;
+        Ok((e.handler.clone(), e.is_async))
+    })?;
+    let call_result = Python::with_gil(|py| -> PyResult<(PyObject, bool)> {
+        let ws = WebSocket::new(protocol.clone_ref(py), scope.clone_ref(py), param_map);
+        let py_ws = Py::new(py, ws)?;
+        let res = handler.bind(py).call1((py_ws,))?.unbind();
+        Ok((res, is_async))
+    });
+    let (res, run_async) = match call_result {
+        Ok(x) => x,
+        Err(e) => {
+            log::error!(target: "oxyroute", "websocket {path} handler raised before await: {e}");
+            let _ = Python::with_gil(|py| -> PyResult<()> {
+                let _ = protocol.bind(py).call_method1("close", (1011i32,));
+                Ok(())
+            });
+            return Ok(Python::with_gil(|py| py.None()));
+        }
+    };
+    if run_async {
+        let fut = match Python::with_gil(|py| {
+            let b = res.bind(py).clone();
+            pyo3_async_runtimes::tokio::into_future(b)
+        }) {
+            Ok(f) => f,
+            Err(e) => {
+                log::error!(target: "oxyroute", "websocket {path} bridge: {e}");
+                let _ = Python::with_gil(|py| -> PyResult<()> {
+                    let _ = protocol.bind(py).call_method1("close", (1011i32,));
+                    Ok(())
+                });
+                return Ok(Python::with_gil(|py| py.None()));
+            }
+        };
+        if let Err(e) = fut.await {
+            log::error!(target: "oxyroute", "websocket {path} handler error: {e}");
+            let _ = Python::with_gil(|py| -> PyResult<()> {
+                let _ = protocol.bind(py).call_method1("close", (1011i32,));
+                Ok(())
+            });
+        }
+    }
+    Ok(Python::with_gil(|py| py.None()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,8 +238,9 @@ impl App {
             .extract()?;
         let (handler_param_names, handler_varkw) = handler_signature_kinds(py, handler.bind(py))?;
         let mut st = self.state.write();
-        let idx = st.routes.len();
-        st.routes.push(state::RouteEntry {
+        let routes = Arc::make_mut(&mut st.routes);
+        let idx = routes.len();
+        routes.push(state::RouteEntry {
             handler,
             is_async,
             require_jwt,
@@ -304,9 +305,9 @@ impl App {
         let f = inspect.getattr("iscoroutinefunction")?;
         let is_async: bool = f.call1((handler.clone_ref(py),))?.extract()?;
         let mut st = self.state.write();
-        let idx = st.websocket_routes.len();
-        st.websocket_routes
-            .push(state::WebsocketRoute { handler, is_async });
+        let ws_routes = Arc::make_mut(&mut st.websocket_routes);
+        let idx = ws_routes.len();
+        ws_routes.push(state::WebsocketRoute { handler, is_async });
         {
             let mut m = st.websocket.lock();
             m.insert(&path, idx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod state;
 mod token;
 mod websocket;
 
-use dispatch::run_rsgi;
+use dispatch::{run_rsgi, try_rsgi_sync_short_circuit};
 use state::AppState;
 
 type ParsedDependencies = (Vec<String>, Vec<Py<PyAny>>, Vec<bool>, Vec<bool>);
@@ -374,6 +374,9 @@ impl App {
         scope: &Bound<'py, PyAny>,
         protocol: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        if let Some(obj) = try_rsgi_sync_short_circuit(py, &this.state, scope, protocol)? {
+            return Ok(obj.into_bound(py));
+        }
         let state = this.state.clone();
         let scope_py: Py<PyAny> = scope.as_any().clone().unbind();
         let protocol_py: Py<PyAny> = protocol.as_any().clone().unbind();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod response;
 mod schema;
 mod state;
 mod token;
+mod websocket;
 
 use dispatch::run_rsgi;
 use state::AppState;
@@ -282,6 +283,39 @@ impl App {
         Ok(())
     }
 
+    /// Register a WebSocket route. ``handler`` receives a single
+    /// :class:`oxyroute._oxyroute.WebSocket` argument; sync handlers run inline, async
+    /// handlers are awaited on Granian's loop. Same matchit ``/ws/:room`` syntax as HTTP routes.
+    fn add_websocket_route(
+        &self,
+        py: Python<'_>,
+        path: String,
+        handler: Py<PyAny>,
+    ) -> PyResult<()> {
+        {
+            let st = self.state.read();
+            if st.frozen {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "app is frozen; no more add_websocket_route",
+                ));
+            }
+        }
+        let inspect = py.import("inspect")?;
+        let f = inspect.getattr("iscoroutinefunction")?;
+        let is_async: bool = f.call1((handler.clone_ref(py),))?.extract()?;
+        let mut st = self.state.write();
+        let idx = st.websocket_routes.len();
+        st.websocket_routes
+            .push(state::WebsocketRoute { handler, is_async });
+        {
+            let mut m = st.websocket.lock();
+            m.insert(&path, idx)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{e}")))?;
+        }
+        st.compiled = None;
+        Ok(())
+    }
+
     /// Lock route registration. Linear dependency list is a valid topological order (DAG of independent roots).
     fn freeze(&self) -> PyResult<()> {
         let mut st = self.state.write();
@@ -378,6 +412,7 @@ impl PyDepends {
 fn _oxyroute(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<App>()?;
     m.add_class::<PyDepends>()?;
+    m.add_class::<websocket::WebSocket>()?;
     m.add_function(wrap_pyfunction!(token::decode_jwt_hs, m)?)?;
     Ok(())
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,9 +22,7 @@ pub async fn send_str(
     content_type: &str,
 ) -> PyResult<PyObject> {
     Python::with_gil(|py| {
-        let p = protocol.bind(py);
-        let h = build_headers_ct(py, Some(content_type))?;
-        p.getattr("response_str")?.call1((status, h, text))?;
+        send_str_sync(py, protocol, status, text, content_type)?;
         Ok(Py::from(pyo3::types::PyNone::get(py)).into_any())
     })
 }
@@ -35,9 +33,7 @@ pub async fn send_empty(
     content_type: Option<&str>,
 ) -> PyResult<PyObject> {
     Python::with_gil(|py| {
-        let p = protocol.bind(py);
-        let h = build_headers_ct(py, content_type)?;
-        p.getattr("response_empty")?.call1((status, h))?;
+        send_empty_sync(py, protocol, status, content_type)?;
         Ok(Py::from(pyo3::types::PyNone::get(py)).into_any())
     })
 }
@@ -49,14 +45,10 @@ pub async fn send_405_method_not_allowed(
     protocol: &Py<PyAny>,
     allow: &[String],
 ) -> PyResult<PyObject> {
-    let headers = vec![
-        ("allow".to_string(), allow.join(", ")),
-        (
-            "content-type".to_string(),
-            "text/plain; charset=utf-8".to_string(),
-        ),
-    ];
-    send_with_headers(protocol, 405, b"Method Not Allowed", headers).await
+    Python::with_gil(|py| {
+        send_405_method_not_allowed_sync(py, protocol, allow)?;
+        Ok(Py::from(pyo3::types::PyNone::get(py)).into_any())
+    })
 }
 
 /// RSGI `response_bytes` / `response_empty` with a full `[(name, value), ...]` header list.
@@ -142,6 +134,34 @@ fn build_headers_ct<'py>(
 
 // ---------- inline (sync, GIL-already-held) RSGI dispatch helpers ----------
 
+/// Sync `protocol.response_str(...)`; for [`try_rsgi_sync_short_circuit`] and async wrappers.
+pub fn send_str_sync(
+    py: Python<'_>,
+    protocol: &Py<PyAny>,
+    status: u16,
+    text: &str,
+    content_type: &str,
+) -> PyResult<()> {
+    let p = protocol.bind(py);
+    let h = build_headers_ct(py, Some(content_type))?;
+    p.getattr("response_str")?.call1((status, h, text))?;
+    Ok(())
+}
+
+/// Sync [`send_text`]: empty string uses `response_empty`.
+pub fn send_text_sync(
+    py: Python<'_>,
+    protocol: &Py<PyAny>,
+    status: u16,
+    text: &str,
+    content_type: &str,
+) -> PyResult<()> {
+    if text.is_empty() {
+        return send_empty_sync(py, protocol, status, Some(content_type));
+    }
+    send_str_sync(py, protocol, status, text, content_type)
+}
+
 /// Sync `protocol.response_bytes(...)`; falls back to `send_empty_sync` on empty body.
 pub fn send_bytes_sync(
     py: Python<'_>,
@@ -188,6 +208,22 @@ pub fn send_with_headers_sync(
         p.getattr("response_bytes")?.call1((status, h, body))?;
     }
     Ok(())
+}
+
+/// Sync 405 with `Allow` and plain body.
+pub fn send_405_method_not_allowed_sync(
+    py: Python<'_>,
+    protocol: &Py<PyAny>,
+    allow: &[String],
+) -> PyResult<()> {
+    let headers = vec![
+        ("allow".to_string(), allow.join(", ")),
+        (
+            "content-type".to_string(),
+            "text/plain; charset=utf-8".to_string(),
+        ),
+    ];
+    send_with_headers_sync(py, protocol, 405, b"Method Not Allowed", headers)
 }
 
 /// HEAD: no body, but `content-length` for `full_body_len`.

--- a/src/state.rs
+++ b/src/state.rs
@@ -30,11 +30,13 @@ fn router_for_compiled<'a>(c: &'a CompiledRouters, method: &str) -> Option<&'a R
 }
 
 /// One WebSocket route: just a handler + async flag (no JWT / deps / body).
+#[derive(Clone)]
 pub struct WebsocketRoute {
     pub handler: Py<PyAny>,
     pub is_async: bool,
 }
 
+#[derive(Clone)]
 pub struct RouteEntry {
     pub handler: Py<PyAny>,
     pub is_async: bool,
@@ -66,8 +68,11 @@ pub struct RouteEntry {
 }
 
 pub struct AppState {
-    pub routes: Vec<RouteEntry>,
-    pub websocket_routes: Vec<WebsocketRoute>,
+    /// Wrapped in `Arc<Vec<…>>` so the hot path can clone a cheap pointer **once** per request and
+    /// release [`AppState`]'s `RwLock` immediately. Mutation goes through [`Arc::make_mut`].
+    pub routes: Arc<Vec<RouteEntry>>,
+    /// Same Arc-snapshot trick as [`routes`](Self::routes); registration uses [`Arc::make_mut`].
+    pub websocket_routes: Arc<Vec<WebsocketRoute>>,
     pub get: Mutex<Router<usize>>,
     pub post: Mutex<Router<usize>>,
     pub put: Mutex<Router<usize>>,
@@ -100,8 +105,8 @@ impl AppState {
             "paths": {}
         });
         Self {
-            routes: Vec::new(),
-            websocket_routes: Vec::new(),
+            routes: Arc::new(Vec::new()),
+            websocket_routes: Arc::new(Vec::new()),
             get: Mutex::new(Router::new()),
             post: Mutex::new(Router::new()),
             put: Mutex::new(Router::new()),
@@ -119,6 +124,24 @@ impl AppState {
         }
     }
 
+    /// Cheap read-side snapshot of the fields the request hot path touches: the
+    /// returned [`HotSnapshot`] is built **inside one** `state.read()` so the request
+    /// dispatch can release the `RwLock` immediately and avoid further reads.
+    ///
+    /// Cheap because every cloned field is `Arc::clone` / `Option<Py<PyAny>>::clone`
+    /// (both refcount bumps), not deep clones.
+    pub fn hot_snapshot(&self) -> HotSnapshot {
+        HotSnapshot {
+            routes: Arc::clone(&self.routes),
+            websocket_routes: Arc::clone(&self.websocket_routes),
+            compiled: self.compiled.as_ref().map(Arc::clone),
+            cors: self.cors.clone(),
+            security_headers: self.security_headers.clone(),
+            middleware: self.middleware.clone(),
+            include_openapi: self.include_openapi,
+        }
+    }
+
     /// Clone current mutex-protected [`Router`]s into a snapshot (used at freeze / tests).
     pub fn snapshot_routers(&self) -> CompiledRouters {
         CompiledRouters {
@@ -133,25 +156,80 @@ impl AppState {
     }
 }
 
-/// Lookup a WebSocket route by path (uses compiled snapshot when available).
-pub fn match_ws_route(state: &AppState, path: &str) -> Option<(usize, HashMap<String, String>)> {
-    if let Some(c) = &state.compiled {
-        return c.websocket.at(path).ok().map(|m| {
-            let mut pmap = HashMap::new();
-            for (k, v) in m.params.iter() {
-                pmap.insert(k.to_string(), v.to_string());
-            }
-            (*m.value, pmap)
-        });
-    }
-    let g = state.websocket.lock();
-    g.at(path).ok().map(|m| {
+/// One-shot read-side view of [`AppState`] for [`run_rsgi`]. All fields are cheap to clone
+/// (`Arc`/`Option<Py<PyAny>>` refcount bumps) so the hot path can drop the `RwLock` after a
+/// single `read()`. See [`AppState::hot_snapshot`].
+pub struct HotSnapshot {
+    pub routes: Arc<Vec<RouteEntry>>,
+    pub websocket_routes: Arc<Vec<WebsocketRoute>>,
+    pub compiled: Option<Arc<CompiledRouters>>,
+    pub cors: Option<Py<PyAny>>,
+    pub security_headers: Option<Py<PyAny>>,
+    pub middleware: Option<Py<PyAny>>,
+    pub include_openapi: bool,
+}
+
+/// Lookup a WebSocket route in a precomputed [`CompiledRouters`] (lock-free).
+pub fn match_ws_route_compiled(
+    compiled: &CompiledRouters,
+    path: &str,
+) -> Option<(usize, HashMap<String, String>)> {
+    compiled.websocket.at(path).ok().map(|m| {
         let mut pmap = HashMap::new();
         for (k, v) in m.params.iter() {
             pmap.insert(k.to_string(), v.to_string());
         }
         (*m.value, pmap)
     })
+}
+
+/// Lookup an HTTP route in a precomputed [`CompiledRouters`] (lock-free).
+///
+/// Returns ``None`` for unsupported method, ``Some(None)`` for no match, ``Some(Some(...))`` on hit.
+pub fn match_route_compiled(
+    compiled: &CompiledRouters,
+    method: &str,
+    path: &str,
+) -> Option<Option<(usize, HashMap<String, String>)>> {
+    let g = router_for_compiled(compiled, method)?;
+    Some(g.at(path).ok().map(|m| {
+        let mut pmap = HashMap::new();
+        for (k, v) in m.params.iter() {
+            pmap.insert(k.to_string(), v.to_string());
+        }
+        (*m.value, pmap)
+    }))
+}
+
+/// All HTTP methods that match `path` in a precomputed [`CompiledRouters`] (lock-free 405 list).
+pub fn methods_matching_path_compiled(compiled: &CompiledRouters, path: &str) -> Vec<String> {
+    const ORDER: [&str; 7] = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"];
+    let mut have = [false; 7];
+    if compiled.get.at(path).is_ok() {
+        have[0] = true;
+        have[1] = true;
+    }
+    if compiled.post.at(path).is_ok() {
+        have[2] = true;
+    }
+    if compiled.put.at(path).is_ok() {
+        have[3] = true;
+    }
+    if compiled.patch.at(path).is_ok() {
+        have[4] = true;
+    }
+    if compiled.delete.at(path).is_ok() {
+        have[5] = true;
+    }
+    if compiled.options.at(path).is_ok() {
+        have[6] = true;
+    }
+    ORDER
+        .iter()
+        .zip(have)
+        .filter(|(_, ok)| *ok)
+        .map(|(m, _)| (*m).to_string())
+        .collect()
 }
 
 pub fn map_method_router<'a>(
@@ -174,7 +252,8 @@ pub fn map_method_router<'a>(
 /// an [`Allow`][1] header when the request method’s router had no match but another would.
 ///
 /// [1]: https://www.rfc-editor.org/rfc/rfc9110#name-405-method-not-allowed
-pub fn methods_matching_path(state: &AppState, path: &str) -> Vec<String> {
+#[cfg(test)]
+fn methods_matching_path(state: &AppState, path: &str) -> Vec<String> {
     const ORDER: [&str; 7] = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"];
     let mut have = [false; 7];
     if let Some(c) = &state.compiled {
@@ -246,7 +325,8 @@ pub fn methods_matching_path(state: &AppState, path: &str) -> Vec<String> {
 
 /// Returns route index and path params, or `None` if the method is unsupported; `Some(None)` if
 /// no match; `Some(Some)` on success. Uses [`CompiledRouters`] when set (lock-free).
-pub fn match_route(
+#[cfg(test)]
+fn match_route(
     state: &AppState,
     method: &str,
     path: &str,

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,6 +14,7 @@ pub struct CompiledRouters {
     pub patch: Router<usize>,
     pub delete: Router<usize>,
     pub options: Router<usize>,
+    pub websocket: Router<usize>,
 }
 
 fn router_for_compiled<'a>(c: &'a CompiledRouters, method: &str) -> Option<&'a Router<usize>> {
@@ -26,6 +27,12 @@ fn router_for_compiled<'a>(c: &'a CompiledRouters, method: &str) -> Option<&'a R
         "OPTIONS" => Some(&c.options),
         _ => None,
     }
+}
+
+/// One WebSocket route: just a handler + async flag (no JWT / deps / body).
+pub struct WebsocketRoute {
+    pub handler: Py<PyAny>,
+    pub is_async: bool,
 }
 
 pub struct RouteEntry {
@@ -60,12 +67,14 @@ pub struct RouteEntry {
 
 pub struct AppState {
     pub routes: Vec<RouteEntry>,
+    pub websocket_routes: Vec<WebsocketRoute>,
     pub get: Mutex<Router<usize>>,
     pub post: Mutex<Router<usize>>,
     pub put: Mutex<Router<usize>>,
     pub patch: Mutex<Router<usize>>,
     pub delete: Mutex<Router<usize>>,
     pub options: Mutex<Router<usize>>,
+    pub websocket: Mutex<Router<usize>>,
     pub openapi: Mutex<serde_json::Value>,
     /// When `Some`, route matching uses these tables without taking per-router mutexes
     /// (populated in [`App::freeze`](crate::App::freeze)).
@@ -92,12 +101,14 @@ impl AppState {
         });
         Self {
             routes: Vec::new(),
+            websocket_routes: Vec::new(),
             get: Mutex::new(Router::new()),
             post: Mutex::new(Router::new()),
             put: Mutex::new(Router::new()),
             patch: Mutex::new(Router::new()),
             delete: Mutex::new(Router::new()),
             options: Mutex::new(Router::new()),
+            websocket: Mutex::new(Router::new()),
             openapi: Mutex::new(openapi),
             compiled: None,
             frozen: false,
@@ -117,8 +128,30 @@ impl AppState {
             patch: self.patch.lock().clone(),
             delete: self.delete.lock().clone(),
             options: self.options.lock().clone(),
+            websocket: self.websocket.lock().clone(),
         }
     }
+}
+
+/// Lookup a WebSocket route by path (uses compiled snapshot when available).
+pub fn match_ws_route(state: &AppState, path: &str) -> Option<(usize, HashMap<String, String>)> {
+    if let Some(c) = &state.compiled {
+        return c.websocket.at(path).ok().map(|m| {
+            let mut pmap = HashMap::new();
+            for (k, v) in m.params.iter() {
+                pmap.insert(k.to_string(), v.to_string());
+            }
+            (*m.value, pmap)
+        });
+    }
+    let g = state.websocket.lock();
+    g.at(path).ok().map(|m| {
+        let mut pmap = HashMap::new();
+        for (k, v) in m.params.iter() {
+            pmap.insert(k.to_string(), v.to_string());
+        }
+        (*m.value, pmap)
+    })
 }
 
 pub fn map_method_router<'a>(

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -211,11 +211,7 @@ impl WebSocket {
     }
 
     /// Send a JSON-serialised object as a text frame (uses :func:`json.dumps`).
-    fn send_json<'py>(
-        &self,
-        py: Python<'py>,
-        data: Py<PyAny>,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn send_json<'py>(&self, py: Python<'py>, data: Py<PyAny>) -> PyResult<Bound<'py, PyAny>> {
         let transport = self.transport_clone(py)?;
         let json_mod = py.import("json")?;
         let dumped = json_mod.call_method1("dumps", (data.bind(py),))?;
@@ -230,25 +226,31 @@ impl WebSocket {
         })
     }
 
-    /// Close the connection. ``code`` defaults to 1000 (normal closure). Idempotent.
+    /// Close the connection. ``code`` defaults to 1000 (normal closure).
+    ///
+    /// Returns an awaitable that completes immediately so handlers can use
+    /// ``await ws.close()``. Idempotent — repeated calls are no-ops.
     #[pyo3(signature = (code=None))]
-    fn close(&self, py: Python<'_>, code: Option<i32>) -> PyResult<Py<PyAny>> {
-        {
+    fn close<'py>(&self, py: Python<'py>, code: Option<i32>) -> PyResult<Bound<'py, PyAny>> {
+        let already_closed = {
             let mut g = self.closed.lock();
-            if *g {
-                return Ok(py.None());
-            }
+            let was = *g;
             *g = true;
+            was
+        };
+        if !already_closed {
+            let st = code.unwrap_or(1000);
+            let _ = self
+                .protocol
+                .bind(py)
+                .call_method1("close", (st,))
+                .map_err(|e| {
+                    log::debug!(target: "oxyroute", "websocket close ignored: {e}");
+                    e
+                });
         }
-        let st = code.unwrap_or(1000);
-        let _ = self
-            .protocol
-            .bind(py)
-            .call_method1("close", (st,))
-            .map_err(|e| {
-                log::debug!(target: "oxyroute", "websocket close ignored: {e}");
-                e
-            });
-        Ok(py.None())
+        pyo3_async_runtimes::tokio::future_into_py(py, async {
+            Python::with_gil(|py| Ok(py.None()))
+        })
     }
 }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -1,0 +1,254 @@
+//! Native RSGI WebSocket helper exposed to Python as ``oxyroute._oxyroute.WebSocket``.
+//!
+//! The Python `@app.websocket(path)` decorator (see [oxyroute/app.py](../oxyroute/app.py))
+//! registers a coroutine handler that receives a [`WebSocket`] instance built around the
+//! underlying Granian [`RSGIWebsocketProtocol`][1]. All async methods delegate directly to
+//! the Granian protocol / transport coroutines so Python keeps awaiting the same objects
+//! it would have awaited natively — no extra Tokio future bridge, no scheduling cost.
+//!
+//! [1]: https://github.com/emmett-framework/granian — see `granian/rsgi.py`.
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyString, PyTuple};
+
+/// Thin async wrapper around a Granian RSGI WebSocket connection.
+///
+/// Lifecycle:
+///
+/// 1. ``await ws.accept()`` performs the WebSocket handshake and stores the underlying transport.
+/// 2. ``await ws.receive()`` / ``receive_text()`` / ``receive_bytes()`` to read frames.
+/// 3. ``await ws.send_text(...)`` / ``send_bytes(...)`` to write frames.
+/// 4. ``await ws.close(code=...)`` to close the connection (defaults to 1000 — normal closure).
+///
+/// All methods are awaitable and run on Granian's event loop; ``close`` is best-effort once
+/// the peer has already disconnected.
+#[pyclass(name = "WebSocket", module = "oxyroute._oxyroute")]
+pub struct WebSocket {
+    protocol: Py<PyAny>,
+    scope: Py<PyAny>,
+    transport: Arc<Mutex<Option<Py<PyAny>>>>,
+    path_params: HashMap<String, String>,
+    closed: Arc<Mutex<bool>>,
+}
+
+impl WebSocket {
+    pub fn new(
+        protocol: Py<PyAny>,
+        scope: Py<PyAny>,
+        path_params: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            protocol,
+            scope,
+            transport: Arc::new(Mutex::new(None)),
+            path_params,
+            closed: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    fn transport_clone(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let g = self.transport.lock();
+        match g.as_ref() {
+            Some(t) => Ok(t.clone_ref(py)),
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "WebSocket: call accept() before send/receive",
+            )),
+        }
+    }
+}
+
+#[pymethods]
+impl WebSocket {
+    /// The Granian RSGI scope (proto = ``"websocket"``).
+    #[getter]
+    fn scope(&self, py: Python<'_>) -> Py<PyAny> {
+        self.scope.clone_ref(py)
+    }
+
+    /// Path parameters extracted by the router (e.g. ``/ws/:room`` → ``{"room": "lobby"}``).
+    #[getter]
+    fn path_params<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new(py);
+        for (k, v) in &self.path_params {
+            d.set_item(k.as_str(), v.as_str())?;
+        }
+        Ok(d)
+    }
+
+    /// True once :meth:`close` has been called (or the peer disconnected).
+    #[getter]
+    fn is_closed(&self) -> bool {
+        *self.closed.lock()
+    }
+
+    /// Perform the handshake. Stores the transport for subsequent send/receive calls.
+    fn accept<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let proto = self.protocol.clone_ref(py);
+        let transport_slot = self.transport.clone();
+        let coro = proto.bind(py).call_method0("accept")?;
+        let fut = pyo3_async_runtimes::tokio::into_future(coro)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let result = fut.await?;
+            Python::with_gil(|py| {
+                *transport_slot.lock() = Some(result);
+                Ok(py.None())
+            })
+        })
+    }
+
+    /// Receive the next WebSocket message; returns ``str`` or ``bytes``. Raises ``RuntimeError``
+    /// if the peer has closed the connection (Granian close kind = 0).
+    fn receive<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let coro = transport.bind(py).call_method0("receive")?;
+        let fut = pyo3_async_runtimes::tokio::into_future(coro)?;
+        let closed_flag = self.closed.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let msg = fut.await?;
+            Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+                let m = msg.bind(py);
+                let kind: i64 = m.getattr("kind")?.extract()?;
+                if kind == 0 {
+                    *closed_flag.lock() = true;
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "WebSocket closed by peer",
+                    ));
+                }
+                let data = m.getattr("data")?;
+                Ok(data.unbind())
+            })
+        })
+    }
+
+    /// Receive the next message as ``str``; raises ``ValueError`` if a binary frame arrives.
+    fn receive_text<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let coro = transport.bind(py).call_method0("receive")?;
+        let fut = pyo3_async_runtimes::tokio::into_future(coro)?;
+        let closed_flag = self.closed.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let msg = fut.await?;
+            Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+                let m = msg.bind(py);
+                let kind: i64 = m.getattr("kind")?.extract()?;
+                if kind == 0 {
+                    *closed_flag.lock() = true;
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "WebSocket closed by peer",
+                    ));
+                }
+                if kind != 2 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "expected text frame",
+                    ));
+                }
+                let data = m.getattr("data")?;
+                let s = data.downcast::<PyString>()?;
+                Ok(s.clone().unbind().into())
+            })
+        })
+    }
+
+    /// Receive the next message as ``bytes``; raises ``ValueError`` if a text frame arrives.
+    fn receive_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let coro = transport.bind(py).call_method0("receive")?;
+        let fut = pyo3_async_runtimes::tokio::into_future(coro)?;
+        let closed_flag = self.closed.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let msg = fut.await?;
+            Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+                let m = msg.bind(py);
+                let kind: i64 = m.getattr("kind")?.extract()?;
+                if kind == 0 {
+                    *closed_flag.lock() = true;
+                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "WebSocket closed by peer",
+                    ));
+                }
+                if kind != 1 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "expected binary frame",
+                    ));
+                }
+                let data = m.getattr("data")?;
+                let b = data.downcast::<PyBytes>()?;
+                Ok(b.clone().unbind().into())
+            })
+        })
+    }
+
+    /// Send a text frame. Returns when Granian has flushed the message.
+    fn send_text<'py>(&self, py: Python<'py>, data: String) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let coro = transport
+            .bind(py)
+            .call_method1("send_str", PyTuple::new(py, [data])?)?;
+        pyo3_async_runtimes::tokio::into_future(coro).and_then(|fut| {
+            pyo3_async_runtimes::tokio::future_into_py(py, async move {
+                fut.await?;
+                Python::with_gil(|py| Ok(py.None()))
+            })
+        })
+    }
+
+    /// Send a binary frame. Returns when Granian has flushed the message.
+    fn send_bytes<'py>(&self, py: Python<'py>, data: Vec<u8>) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let pb = PyBytes::new(py, &data);
+        let coro = transport
+            .bind(py)
+            .call_method1("send_bytes", PyTuple::new(py, [pb])?)?;
+        pyo3_async_runtimes::tokio::into_future(coro).and_then(|fut| {
+            pyo3_async_runtimes::tokio::future_into_py(py, async move {
+                fut.await?;
+                Python::with_gil(|py| Ok(py.None()))
+            })
+        })
+    }
+
+    /// Send a JSON-serialised object as a text frame (uses :func:`json.dumps`).
+    fn send_json<'py>(
+        &self,
+        py: Python<'py>,
+        data: Py<PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let transport = self.transport_clone(py)?;
+        let json_mod = py.import("json")?;
+        let dumped = json_mod.call_method1("dumps", (data.bind(py),))?;
+        let coro = transport
+            .bind(py)
+            .call_method1("send_str", PyTuple::new(py, [dumped])?)?;
+        pyo3_async_runtimes::tokio::into_future(coro).and_then(|fut| {
+            pyo3_async_runtimes::tokio::future_into_py(py, async move {
+                fut.await?;
+                Python::with_gil(|py| Ok(py.None()))
+            })
+        })
+    }
+
+    /// Close the connection. ``code`` defaults to 1000 (normal closure). Idempotent.
+    #[pyo3(signature = (code=None))]
+    fn close(&self, py: Python<'_>, code: Option<i32>) -> PyResult<Py<PyAny>> {
+        {
+            let mut g = self.closed.lock();
+            if *g {
+                return Ok(py.None());
+            }
+            *g = true;
+        }
+        let st = code.unwrap_or(1000);
+        let _ = self
+            .protocol
+            .bind(py)
+            .call_method1("close", (st,))
+            .map_err(|e| {
+                log::debug!(target: "oxyroute", "websocket close ignored: {e}");
+                e
+            });
+        Ok(py.None())
+    }
+}

--- a/tests/_rsgi_test_transport.py
+++ b/tests/_rsgi_test_transport.py
@@ -199,7 +199,11 @@ class _RsgiProtocol:
         self.status = 200
 
     def _enqueue(self, message: dict[str, Any]) -> None:
-        self._loop.call_soon_threadsafe(self._queue.put_nowait, message)
+        # This method runs from the executor thread that drives the native RSGI
+        # dispatcher. Wait until the main loop has actually queued the ASGI
+        # message so the final sentinel cannot overtake response.start/body on
+        # Python 3.14's event-loop scheduling.
+        asyncio.run_coroutine_threadsafe(self._queue.put(message), self._loop).result()
 
     def __call__(self) -> Any:
         async def _body() -> bytes:

--- a/tests/_rsgi_test_transport.py
+++ b/tests/_rsgi_test_transport.py
@@ -12,6 +12,7 @@ instance to obtain an ASGI 3 callable that proxies into the native RSGI dispatch
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import threading
 from collections.abc import Callable
@@ -98,6 +99,9 @@ def _run_handle_rsgi_blocking(
 ) -> None:
     async def _inner() -> None:
         c = app_rsgi(rscope, proto)
+        # Native ``handle_rsgi`` may return ``None`` (sync short-circuit: openapi / 4xx) or a Future.
+        if c is None or not inspect.isawaitable(c):
+            return
         await c
 
     loop = getattr(_BLOCKING_LOOP_LOCAL, "loop", None)

--- a/tests/test_perf_hello_bench.py
+++ b/tests/test_perf_hello_bench.py
@@ -1,0 +1,52 @@
+"""
+Optional hello-world RPS comparison: OxyRoute (RSGI) vs FastAPI (ASGI) via ``wrk``.
+
+Skipped unless ``OXYROUTE_BENCH=1``. Requires ``pip install -e '.[bench]'``, ``wrk``,
+and a built ``oxyroute`` extension (``maturin develop`` / wheel).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("granian")
+pytest.importorskip("fastapi")
+
+skip_bench = pytest.mark.skipif(
+    os.environ.get("OXYROUTE_BENCH") != "1",
+    reason="set OXYROUTE_BENCH=1 to run wrk comparison (optional; not for CI by default)",
+)
+
+
+@skip_bench
+@pytest.mark.bench
+def test_bench_hello_script_oxyroute_vs_fastapi() -> None:
+    if not shutil.which("wrk"):
+        pytest.skip("wrk not on PATH")
+    if not shutil.which("bash"):
+        pytest.skip("bash not on PATH")
+    root = Path(__file__).resolve().parent.parent
+    script = root / "perf-test" / "bench_hello.sh"
+    if not script.is_file():
+        pytest.skip("perf-test/bench_hello.sh not found")
+    env = {**os.environ, "OXYROUTE_BENCH_DURATION": "1s", "OXYROUTE_BENCH_CONNECTIONS": "8"}
+    proc = subprocess.run(
+        ["bash", str(script)],
+        cwd=str(root),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    assert "OxyRoute" in out
+    assert "FastAPI" in out
+    assert "Delta" in out
+    assert "Requests/sec" in out

--- a/tests/test_sync_rsgi_short_circuit.py
+++ b/tests/test_sync_rsgi_short_circuit.py
@@ -1,0 +1,56 @@
+"""
+RSGI sync short-circuit: ``openapi`` / 404 / 405 return without ``future_into_py`` (see ``try_rsgi_sync_short_circuit``).
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from typing import Any
+
+
+from oxyroute import App
+
+
+class _ProtoText:
+    __slots__ = ("sent",)
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[int, str, str]] = []
+
+    def response_str(self, status: int, _headers: list, body: str) -> None:
+        self.sent.append((status, body, "str"))
+
+
+def test_handle_rsgi_openapi_get_returns_non_awaitable() -> None:
+    app = App(title="Doc")
+    scope = SimpleNamespace(
+        proto="http",
+        method="GET",
+        path="/openapi.json",
+        query_string="",
+        headers={},
+    )
+    proto = _ProtoText()
+    r = app.handle_rsgi(scope, proto)
+    assert r is None
+    assert not inspect.isawaitable(r)
+    assert proto.sent and proto.sent[0][0] == 200
+    assert "openapi" in proto.sent[0][1]
+
+
+def test_handle_rsgi_404_returns_non_awaitable() -> None:
+    app = App()
+    scope = SimpleNamespace(
+        proto="http",
+        method="GET",
+        path="/no-such",
+        query_string="",
+        headers={},
+    )
+    proto = _ProtoText()
+    r = app.handle_rsgi(scope, proto)
+    assert r is None
+    assert not inspect.isawaitable(r)
+    assert proto.sent[0][0] == 404
+    assert "Not Found" in proto.sent[0][1]

--- a/tests/test_sync_rsgi_short_circuit.py
+++ b/tests/test_sync_rsgi_short_circuit.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 import inspect
 from types import SimpleNamespace
-from typing import Any
-
 
 from oxyroute import App
 

--- a/tests/test_websocket_native.py
+++ b/tests/test_websocket_native.py
@@ -1,0 +1,232 @@
+"""Unit tests for the native RSGI WebSocket dispatch path (no ASGI involved).
+
+Drives :meth:`oxyroute.app.App.handle_rsgi` directly with a mocked Granian-style
+``scope`` / ``protocol`` pair (see :class:`granian.rsgi.RSGIWebsocketProtocol` /
+:class:`granian.rsgi.RSGIWebsocketTransport` for the live equivalents). The mocks
+return real ``asyncio`` coroutines so ``pyo3-async-runtimes`` can bridge them
+to Rust the same way Granian does at runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from oxyroute import App, WebSocket
+
+
+@dataclass
+class _Headers:
+    pairs: list[tuple[str, str]] = field(default_factory=list)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        for k, v in self.pairs:
+            if k.lower() == key.lower():
+                return v
+        return default
+
+
+@dataclass
+class _WSScope:
+    proto: str = "websocket"
+    path: str = "/"
+    method: str = "GET"
+    query_string: str = ""
+    http_version: str = "1.1"
+    rsgi_version: str = "1.5"
+    server: str = "127.0.0.1:8000"
+    client: str = "127.0.0.1:1234"
+    scheme: str = "http"
+    authority: str | None = None
+    headers: _Headers = field(default_factory=_Headers)
+
+
+class _MockMessage:
+    """Mirrors :class:`granian.rsgi.WebsocketMessage` (kind / data)."""
+
+    __slots__ = ("data", "kind")
+
+    def __init__(self, kind: int, data: Any) -> None:
+        self.kind = kind
+        self.data = data
+
+
+class _MockTransport:
+    """Stand-in for :class:`granian.rsgi.RSGIWebsocketTransport`."""
+
+    def __init__(self, incoming: list[_MockMessage]) -> None:
+        self._incoming = list(incoming)
+        self.sent: list[tuple[str, Any]] = []
+
+    async def receive(self) -> _MockMessage:
+        if not self._incoming:
+            return _MockMessage(0, b"")
+        return self._incoming.pop(0)
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(("text", data))
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent.append(("bytes", bytes(data)))
+
+
+class _MockProtocol:
+    """Stand-in for :class:`granian.rsgi.RSGIWebsocketProtocol`."""
+
+    def __init__(self, incoming: list[_MockMessage] | None = None) -> None:
+        self._incoming = incoming or []
+        self.transport: _MockTransport | None = None
+        self.closed_with: int | None = None
+
+    async def accept(self) -> _MockTransport:
+        self.transport = _MockTransport(self._incoming)
+        return self.transport
+
+    def close(self, status: int | None) -> tuple[int, bool]:
+        self.closed_with = int(status) if status is not None else 1000
+        return (self.closed_with, True)
+
+
+def _drive(app: App, scope: Any, proto: Any) -> None:
+    """Run ``app.handle_rsgi(scope, proto)`` to completion on a fresh event loop.
+
+    ``pyo3-async-runtimes`` needs an active asyncio loop *at the moment* the Rust
+    side calls ``future_into_py``, so we always invoke ``handle_rsgi`` from inside
+    a coroutine rather than synchronously from the test body.
+    """
+
+    async def _inner() -> None:
+        await app.handle_rsgi(scope, proto)
+
+    asyncio.run(_inner())
+
+
+def test_websocket_decorator_registers_route() -> None:
+    app = App()
+
+    @app.websocket("/ws")
+    async def handler(ws: WebSocket) -> None:
+        await ws.accept()
+        await ws.close()
+
+    assert handler.__name__ == "handler"
+
+
+def test_websocket_echo_round_trip() -> None:
+    app = App()
+
+    @app.websocket("/ws/:room")
+    async def echo(ws: WebSocket) -> None:
+        assert ws.path_params["room"] == "lobby"
+        await ws.accept()
+        msg = await ws.receive_text()
+        await ws.send_text(f"echo:{msg}")
+        await ws.send_bytes(b"binary")
+        await ws.close()
+
+    proto = _MockProtocol(incoming=[_MockMessage(2, "hello")])
+    _drive(app, _WSScope(path="/ws/lobby"), proto)
+
+    assert proto.transport is not None
+    assert proto.transport.sent == [("text", "echo:hello"), ("bytes", b"binary")]
+    assert proto.closed_with == 1000
+
+
+def test_websocket_send_json() -> None:
+    app = App()
+
+    @app.websocket("/json")
+    async def push_json(ws: WebSocket) -> None:
+        await ws.accept()
+        await ws.send_json({"a": 1, "b": [2, 3]})
+        await ws.close()
+
+    proto = _MockProtocol()
+    _drive(app, _WSScope(path="/json"), proto)
+
+    assert proto.transport is not None
+    assert proto.transport.sent[0][0] == "text"
+    import json
+
+    assert json.loads(proto.transport.sent[0][1]) == {"a": 1, "b": [2, 3]}
+
+
+def test_websocket_no_route_closes_polite() -> None:
+    app = App()
+    proto = _MockProtocol()
+    _drive(app, _WSScope(path="/missing"), proto)
+    assert proto.closed_with == 1000
+    assert proto.transport is None
+
+
+def test_websocket_handler_error_closes_with_1011() -> None:
+    app = App()
+
+    @app.websocket("/boom")
+    async def boom(ws: WebSocket) -> None:
+        await ws.accept()
+        raise RuntimeError("boom")
+
+    proto = _MockProtocol()
+    _drive(app, _WSScope(path="/boom"), proto)
+    assert proto.closed_with == 1011
+
+
+def test_websocket_peer_close_marks_closed() -> None:
+    """When the peer sends a close frame, ``receive_text`` raises and our side
+    must not redundantly call ``protocol.close()`` (Granian handled the close).
+    """
+
+    app = App()
+    after_state: dict[str, Any] = {}
+
+    @app.websocket("/peer-close")
+    async def peer_close(ws: WebSocket) -> None:
+        await ws.accept()
+        with pytest.raises(RuntimeError, match="closed by peer"):
+            await ws.receive_text()
+        after_state["is_closed"] = ws.is_closed
+        await ws.close()
+
+    proto = _MockProtocol(incoming=[_MockMessage(0, b"")])
+    _drive(app, _WSScope(path="/peer-close"), proto)
+    assert after_state["is_closed"] is True
+    assert proto.closed_with is None
+
+
+def test_websocket_kind_mismatch_raises_value_error() -> None:
+    app = App()
+
+    @app.websocket("/strict-text")
+    async def strict_text(ws: WebSocket) -> None:
+        await ws.accept()
+        with pytest.raises(ValueError):
+            await ws.receive_text()
+        await ws.close()
+
+    proto = _MockProtocol(incoming=[_MockMessage(1, b"binary-not-text")])
+    _drive(app, _WSScope(path="/strict-text"), proto)
+
+
+def test_websocket_send_before_accept_raises() -> None:
+    app = App()
+
+    @app.websocket("/no-accept")
+    async def no_accept(ws: WebSocket) -> None:
+        with pytest.raises(RuntimeError, match="accept"):
+            await ws.send_text("nope")
+        await ws.close()
+
+    proto = _MockProtocol()
+    _drive(app, _WSScope(path="/no-accept"), proto)
+
+
+def test_websocket_frozen_app_rejects_route() -> None:
+    app = App()
+    app.freeze()
+    with pytest.raises(ValueError, match="frozen"):
+
+        @app.websocket("/late")
+        async def late(ws: WebSocket) -> None: ...

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -210,6 +219,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
 name = "granian"
 version = "2.7.4"
 source = { registry = "https://pypi.org/simple" }
@@ -396,6 +421,11 @@ version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
+bench = [
+    { name = "fastapi" },
+    { name = "granian" },
+    { name = "httpx" },
+]
 dev = [
     { name = "cryptography" },
     { name = "granian" },
@@ -411,7 +441,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", marker = "extra == 'dev'", specifier = ">=42" },
+    { name = "fastapi", marker = "extra == 'bench'", specifier = ">=0.100" },
+    { name = "granian", marker = "extra == 'bench'", specifier = ">=1.0" },
     { name = "granian", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "httpx", marker = "extra == 'bench'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.4,<2" },
     { name = "oxyjwt", marker = "extra == 'dev'", specifier = ">=0.2" },
@@ -420,7 +453,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "bench"]
 
 [[package]]
 name = "packaging"
@@ -642,6 +675,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add native RSGI WebSocket route registry/dispatch and Python `@app.websocket(...)` surface, with ASGI websocket bridge/tests removed in favor of native coverage
- add sync RSGI short-circuit for `openapi`/404/405 and make `App.__rsgi__` + test transport handle non-awaitable native returns safely
- harden perf harnesses: stable venv/granian launch, dynamic ports, process-group cleanup, fair FastAPI plain-text responses, and clearer ratio/uplift reporting

## Test plan
- [x] `uv run pytest tests/ -q`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] smoke: `OXYROUTE_BENCH_DURATION=1s OXYROUTE_BENCH_RUNS=1 OXYROUTE_BENCH_CONNECTIONS=16 OXYROUTE_BENCH_THREADS=1 bash perf-test/bench.sh`

Closes #90