### PR TITLE
perf(dispatch): sync fast path for trivial matched routes

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -122,11 +122,7 @@ async fn try_http_exception(protocol: &Py<PyAny>, err: &PyErr) -> PyResult<Optio
     Ok(Some(out))
 }
 
-fn try_http_exception_sync(
-    py: Python<'_>,
-    protocol: &Py<PyAny>,
-    err: &PyErr,
-) -> PyResult<bool> {
+fn try_http_exception_sync(py: Python<'_>, protocol: &Py<PyAny>, err: &PyErr) -> PyResult<bool> {
     let Some((st, body, mut headers)) = http_exception_payload(py, err)? else {
         return Ok(false);
     };
@@ -160,13 +156,7 @@ fn send_internal_error_sync(
     } else {
         r#"{"error":"internal server error"}"#.to_string()
     };
-    response::send_text_sync(
-        py,
-        protocol,
-        500,
-        &body,
-        "application/json; charset=utf-8",
-    )
+    response::send_text_sync(py, protocol, 500, &body, "application/json; charset=utf-8")
 }
 
 fn send_python_error_sync(

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -14,8 +14,8 @@ use crate::params::{build_request_context, header_get_lax, parse_query, value_fo
 use crate::response;
 use crate::schema::json_to_py;
 use crate::state::{
-    match_route_compiled, match_ws_route_compiled, methods_matching_path_compiled, AppState,
-    CompiledRouters, HotSnapshot, RouteEntry,
+    match_route_compiled, match_ws_route_compiled, methods_matching_path_compiled,
+    route_is_trivial_sync, AppState, CompiledRouters, HotSnapshot, RouteEntry,
 };
 use crate::token::{build_decoding_key, extract_bearer, extract_cookie_value};
 use crate::websocket::WebSocket;
@@ -64,42 +64,38 @@ async fn send_internal_error(
     response::send_text(protocol, 500, &body, "application/json; charset=utf-8").await
 }
 
-/// If ``err`` is :class:`oxyroute.exceptions.HTTPException`, send status/body/headers; else ``None``.
-async fn try_http_exception(protocol: &Py<PyAny>, err: &PyErr) -> PyResult<Option<PyObject>> {
-    let payload: Option<HttpExceptionPayload> =
-        Python::with_gil(|py| -> PyResult<Option<HttpExceptionPayload>> {
-            let m = py.import("oxyroute.exceptions")?;
-            let f = m.getattr("_http_exception_payload")?;
-            let exc = err.value(py);
-            let r = f.call1((exc,))?;
-            if r.is_none() {
-                return Ok(None);
-            }
-            let tup = r.downcast::<PyTuple>()?;
-            if tup.len() != 3 {
-                return Ok(None);
-            }
-            let status: u16 = tup.get_item(0)?.extract()?;
-            let b = tup.get_item(1)?;
-            let body: Vec<u8> = b.extract()?;
-            let h = tup.get_item(2)?;
-            let list = h.downcast::<PyList>()?;
-            let mut headers = Vec::new();
-            for i in 0..list.len() {
-                let item = list.get_item(i)?;
-                let pair = item.downcast::<PyTuple>()?;
-                let k: String = pair.get_item(0)?.extract()?;
-                let v: String = pair.get_item(1)?.extract()?;
-                if contains_crlf(&k) || contains_crlf(&v) {
-                    return Ok(None);
-                }
-                headers.push((k, v));
-            }
-            Ok(Some((status, body, headers)))
-        })?;
-    let Some((st, body, mut headers)) = payload else {
+fn http_exception_payload(py: Python<'_>, err: &PyErr) -> PyResult<Option<HttpExceptionPayload>> {
+    let m = py.import("oxyroute.exceptions")?;
+    let f = m.getattr("_http_exception_payload")?;
+    let exc = err.value(py);
+    let r = f.call1((exc,))?;
+    if r.is_none() {
         return Ok(None);
-    };
+    }
+    let tup = r.downcast::<PyTuple>()?;
+    if tup.len() != 3 {
+        return Ok(None);
+    }
+    let status: u16 = tup.get_item(0)?.extract()?;
+    let b = tup.get_item(1)?;
+    let body: Vec<u8> = b.extract()?;
+    let h = tup.get_item(2)?;
+    let list = h.downcast::<PyList>()?;
+    let mut headers = Vec::new();
+    for i in 0..list.len() {
+        let item = list.get_item(i)?;
+        let pair = item.downcast::<PyTuple>()?;
+        let k: String = pair.get_item(0)?.extract()?;
+        let v: String = pair.get_item(1)?.extract()?;
+        if contains_crlf(&k) || contains_crlf(&v) {
+            return Ok(None);
+        }
+        headers.push((k, v));
+    }
+    Ok(Some((status, body, headers)))
+}
+
+fn ensure_http_exception_content_type(headers: &mut Vec<(String, String)>) {
     let has_ct = headers
         .iter()
         .any(|(k, _)| k.eq_ignore_ascii_case("content-type"));
@@ -112,8 +108,105 @@ async fn try_http_exception(protocol: &Py<PyAny>, err: &PyErr) -> PyResult<Optio
             ),
         );
     }
+}
+
+/// If ``err`` is :class:`oxyroute.exceptions.HTTPException`, send status/body/headers; else ``None``.
+async fn try_http_exception(protocol: &Py<PyAny>, err: &PyErr) -> PyResult<Option<PyObject>> {
+    let payload: Option<HttpExceptionPayload> =
+        Python::with_gil(|py| http_exception_payload(py, err))?;
+    let Some((st, body, mut headers)) = payload else {
+        return Ok(None);
+    };
+    ensure_http_exception_content_type(&mut headers);
     let out = response::send_with_headers(protocol, st, &body, headers).await?;
     Ok(Some(out))
+}
+
+fn try_http_exception_sync(
+    py: Python<'_>,
+    protocol: &Py<PyAny>,
+    err: &PyErr,
+) -> PyResult<bool> {
+    let Some((st, body, mut headers)) = http_exception_payload(py, err)? else {
+        return Ok(false);
+    };
+    ensure_http_exception_content_type(&mut headers);
+    response::send_with_headers_sync(py, protocol, st, &body, headers)?;
+    Ok(true)
+}
+
+fn send_internal_error_sync(
+    py: Python<'_>,
+    protocol: &Py<PyAny>,
+    method: &str,
+    path: &str,
+    err: PyErr,
+) -> PyResult<()> {
+    let detail_opt = if oxyroute_debug() {
+        let d = format!("{err}");
+        let d = if d.len() > 4000 {
+            format!("{}…", &d[..4000])
+        } else {
+            d
+        };
+        log::error!(target: "oxyroute", "{method} {path} — {d}");
+        Some(d)
+    } else {
+        log::error!(target: "oxyroute", "{method} {path}: internal error (set OXYROUTE_DEBUG=1 for detail)");
+        None
+    };
+    let body = if let Some(d) = detail_opt {
+        serde_json::json!({ "error": "internal server error", "detail": d }).to_string()
+    } else {
+        r#"{"error":"internal server error"}"#.to_string()
+    };
+    response::send_text_sync(
+        py,
+        protocol,
+        500,
+        &body,
+        "application/json; charset=utf-8",
+    )
+}
+
+fn send_python_error_sync(
+    py: Python<'_>,
+    protocol: &Py<PyAny>,
+    method: &str,
+    path: &str,
+    err: PyErr,
+) -> PyResult<()> {
+    if try_http_exception_sync(py, protocol, &err)? {
+        return Ok(());
+    }
+    send_internal_error_sync(py, protocol, method, path, err)
+}
+
+fn run_trivial_sync_route(
+    py: Python<'_>,
+    protocol: &Py<PyAny>,
+    method: &str,
+    path: &str,
+    is_head: bool,
+    entry: &RouteEntry,
+) -> PyResult<()> {
+    let handler = entry.handler.bind(py);
+    let out = match handler.call0() {
+        Ok(x) => x.unbind(),
+        Err(e) => {
+            return send_python_error_sync(py, protocol, method, path, e);
+        }
+    };
+    let mapped = match map_handler_return(py, &out) {
+        Ok(m) => m,
+        Err(e) => {
+            return send_python_error_sync(py, protocol, method, path, e);
+        }
+    };
+    if let Err(e) = send_handler_map_inline(py, protocol, is_head, mapped) {
+        return send_python_error_sync(py, protocol, method, path, e);
+    }
+    Ok(())
 }
 
 /// Like [`send_internal_error`], but maps :class:`HTTPException` to its status and body.
@@ -140,10 +233,12 @@ fn ensure_compiled_snapshot(state: &Arc<RwLock<AppState>>) -> Arc<CompiledRouter
     Arc::clone(st.compiled.as_ref().expect("just populated"))
 }
 
-/// Synchronous RSGI handling for **openapi**, **404**, and **405** only: no `protocol()` body read
-/// and no `future_into_py` outer bridge (saves a Tokio task + asyncio Future on these paths).
+/// Synchronous RSGI handling for **openapi**, **404**, **405**, and **trivial matched routes**:
+/// no `protocol()` body read and no `future_into_py` outer bridge (saves a Tokio task + asyncio
+/// Future on these paths).
 ///
-/// Returns `Ok(None)` if [`run_rsgi`] (async) must be used. Middleware always defers to async.
+/// Returns `Ok(None)` if [`run_rsgi`] (async) must be used. Middleware, CORS, and security-header
+/// presets always defer to async.
 pub fn try_rsgi_sync_short_circuit(
     py: Python<'_>,
     state: &Arc<RwLock<AppState>>,
@@ -162,6 +257,7 @@ pub fn try_rsgi_sync_short_circuit(
     let path: String = scope.getattr("path")?.extract()?;
     let is_head = method == "HEAD";
     let snapshot = state.read().hot_snapshot();
+    let needs_response_cfg_merge = snapshot.cors.is_some() || snapshot.security_headers.is_some();
     if snapshot.middleware.is_some() {
         return Ok(None);
     }
@@ -201,7 +297,20 @@ pub fn try_rsgi_sync_short_circuit(
         Some(m) => m,
     };
     match route_out {
-        Some((_, _)) => Ok(None),
+        Some((idx, _)) => {
+            if needs_response_cfg_merge {
+                return Ok(None);
+            }
+            let routes = Arc::clone(&snapshot.routes);
+            let Some(entry) = routes.get(idx) else {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err("route index"));
+            };
+            if route_is_trivial_sync(entry) {
+                run_trivial_sync_route(py, &protocol_py, &method, &path, is_head, entry)?;
+                return Ok(Some(py.None()));
+            }
+            Ok(None)
+        }
         None => {
             let m = methods_matching_path_compiled(&compiled, &path);
             if m.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,13 @@ impl App {
             .getattr(pyo3::intern!(py, "__name__"))?
             .extract()?;
         let (handler_param_names, handler_varkw) = handler_signature_kinds(py, handler.bind(py))?;
+        let trivial_sync = !is_async
+            && !require_jwt
+            && !read_json_body
+            && !read_form_body
+            && dep_factories.is_empty()
+            && !handler_varkw
+            && handler_param_names.is_empty();
         let mut st = self.state.write();
         let routes = Arc::make_mut(&mut st.routes);
         let idx = routes.len();
@@ -258,6 +265,7 @@ impl App {
             dep_wants_request: Arc::<[bool]>::from(dep_wants_request),
             handler_param_names: Arc::new(handler_param_names),
             handler_varkw,
+            trivial_sync,
         });
         let request_schema: Option<serde_json::Value> = match body_schema_json
             .as_deref()

--- a/src/state.rs
+++ b/src/state.rs
@@ -65,6 +65,14 @@ pub struct RouteEntry {
     pub handler_param_names: Arc<HashSet<String>>,
     /// Handler has `**kwargs` (pass all dependency kwargs).
     pub handler_varkw: bool,
+    /// Sync ``call0()`` route with no body/JWT/deps/kwargs — eligible for RSGI sync fast path.
+    pub trivial_sync: bool,
+}
+
+/// True when the route can be served by [`try_rsgi_sync_short_circuit`](crate::dispatch::try_rsgi_sync_short_circuit)
+/// without body read, JWT, or dependency resolution.
+pub fn route_is_trivial_sync(entry: &RouteEntry) -> bool {
+    entry.trivial_sync
 }
 
 pub struct AppState {

--- a/tests/test_sync_rsgi_short_circuit.py
+++ b/tests/test_sync_rsgi_short_circuit.py
@@ -1,9 +1,11 @@
 """
-RSGI sync short-circuit: ``openapi`` / 404 / 405 return without ``future_into_py`` (see ``try_rsgi_sync_short_circuit``).
+RSGI sync short-circuit: ``openapi`` / 404 / 405 / trivial matched routes return without
+``future_into_py`` (see ``try_rsgi_sync_short_circuit``).
 """
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from types import SimpleNamespace
 
@@ -18,6 +20,9 @@ class _ProtoText:
 
     def response_str(self, status: int, _headers: list, body: str) -> None:
         self.sent.append((status, body, "str"))
+
+    def response_bytes(self, status: int, _headers: list, body: bytes) -> None:
+        self.sent.append((status, body.decode("utf-8"), "bytes"))
 
 
 def test_handle_rsgi_openapi_get_returns_non_awaitable() -> None:
@@ -52,3 +57,51 @@ def test_handle_rsgi_404_returns_non_awaitable() -> None:
     assert not inspect.isawaitable(r)
     assert proto.sent[0][0] == 404
     assert "Not Found" in proto.sent[0][1]
+
+
+def test_handle_rsgi_trivial_matched_route_returns_non_awaitable() -> None:
+    app = App()
+
+    @app.get("/hello")
+    def hello() -> str:
+        return "hello"
+
+    scope = SimpleNamespace(
+        proto="http",
+        method="GET",
+        path="/hello",
+        query_string="",
+        headers={},
+    )
+    proto = _ProtoText()
+    r = app.handle_rsgi(scope, proto)
+    assert r is None
+    assert not inspect.isawaitable(r)
+    assert proto.sent and proto.sent[0][0] == 200 and proto.sent[0][1] == "hello"
+
+
+def test_handle_rsgi_route_with_deps_still_awaitable() -> None:
+    app = App()
+
+    def dep() -> int:
+        return 1
+
+    @app.get("/x", dependencies=[("n", dep)])
+    def x(n: int) -> str:
+        return str(n)
+
+    scope = SimpleNamespace(
+        proto="http",
+        method="GET",
+        path="/x",
+        query_string="",
+        headers={},
+    )
+    proto = _ProtoText()
+
+    async def check() -> None:
+        r = app.handle_rsgi(scope, proto)
+        assert inspect.isawaitable(r)
+        await r
+
+    asyncio.run(check())


### PR DESCRIPTION
## Summary
- Mark routes as `trivial_sync` at registration when they are sync `call0()` handlers with no body/JWT/deps/kwargs.
- Extend `try_rsgi_sync_short_circuit` to invoke matched trivial routes synchronously (handler → map → RSGI send) without `future_into_py`.
- Defer to the async path when middleware, CORS, or security-header presets are enabled.
- Add sync HTTPException/500 handling and tests for trivial vs dependency routes.

Closes #94

## Test plan
- [x] `uv run pytest tests/test_sync_rsgi_short_circuit.py`
- [ ] Maintainer: `make test`