### PR TITLE
perf(json): convert serde_json directly to Python objects

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -850,12 +850,12 @@ pub async fn run_rsgi(
                 }
             }
         }
-        if let Some(c) = claims_val {
+        if let Some(ref c) = claims_val {
             let pyv = json_to_py(py, c)?;
             kwargs.set_item("claims", pyv)?;
         }
         if let Some(ref j) = body_json {
-            let pyv = json_to_py(py, j.clone())?;
+            let pyv = json_to_py(py, j)?;
             kwargs.set_item("json", pyv)?;
         }
         if read_form_body {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,11 +1,51 @@
 //! JSON to Python and minimal body validation (object/array root).
 
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyFloat, PyList, PyString};
+use pyo3::IntoPyObjectExt;
+use serde_json::Number;
 use serde_json::Value as JsonValue;
 
-pub fn json_to_py(py: Python<'_>, v: JsonValue) -> PyResult<Py<PyAny>> {
-    let s = serde_json::to_string(&v)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-    let json = py.import("json")?;
-    Ok(json.call_method1("loads", (s,))?.unbind())
+fn json_number_to_py(py: Python<'_>, n: &Number) -> PyResult<Py<PyAny>> {
+    if let Some(i) = n.as_i64() {
+        return i.into_py_any(py);
+    }
+    if let Some(u) = n.as_u64() {
+        return u.into_py_any(py);
+    }
+    if let Some(f) = n.as_f64() {
+        return Ok(PyFloat::new(py, f).unbind().into());
+    }
+    Err(pyo3::exceptions::PyValueError::new_err(
+        "invalid JSON number",
+    ))
+}
+
+fn json_value_to_py(py: Python<'_>, v: &JsonValue) -> PyResult<Py<PyAny>> {
+    match v {
+        JsonValue::Null => Ok(py.None()),
+        JsonValue::Bool(b) => Ok(b.into_py_any(py)?),
+        JsonValue::Number(n) => json_number_to_py(py, n),
+        JsonValue::String(s) => Ok(PyString::new(py, s).into()),
+        JsonValue::Array(items) => {
+            let list = PyList::empty(py);
+            for item in items {
+                list.append(json_value_to_py(py, item)?)?;
+            }
+            Ok(list.into())
+        }
+        JsonValue::Object(map) => {
+            let dict = PyDict::new(py);
+            for (k, val) in map {
+                dict.set_item(k, json_value_to_py(py, val)?)?;
+            }
+            Ok(dict.into())
+        }
+    }
+}
+
+/// Convert a parsed ``serde_json::Value`` into an equivalent Python object without a JSON
+/// string roundtrip through ``json.loads``.
+pub fn json_to_py(py: Python<'_>, v: &JsonValue) -> PyResult<Py<PyAny>> {
+    json_value_to_py(py, v)
 }

--- a/tests/test_json_body.py
+++ b/tests/test_json_body.py
@@ -1,0 +1,50 @@
+"""JSON request body injection via native ``json_to_py`` (issue #95)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+from oxyroute import App
+from tests._rsgi_test_transport import asgi_test_app
+
+
+def test_json_body_nested_types() -> None:
+    app = App()
+    seen: dict[str, object] = {}
+
+    @app.post("/echo")
+    def echo(json: dict) -> str:
+        seen["json"] = json
+        return "ok"
+
+    payload = {"a": 1, "b": [None, False, "x"], "c": {"d": 2.5}}
+
+    async def _run() -> None:
+        transport = httpx.ASGITransport(app=asgi_test_app(app))
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            r = await c.post("/echo", json=payload)
+        assert r.status_code == 200, r.text
+        assert r.text == "ok"
+
+    asyncio.run(_run())
+    assert seen["json"] == payload
+
+
+def test_json_body_scalar_and_empty_object() -> None:
+    app = App()
+    seen: dict[str, object] = {}
+
+    @app.post("/nums")
+    def nums(json: dict) -> str:
+        seen["json"] = json
+        return "ok"
+
+    async def _run() -> None:
+        transport = httpx.ASGITransport(app=asgi_test_app(app))
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            r = await c.post("/nums", json={"n": 42, "f": 1.25, "s": "z", "t": True, "u": {}})
+        assert r.status_code == 200, r.text
+
+    asyncio.run(_run())
+    assert seen["json"] == {"n": 42, "f": 1.25, "s": "z", "t": True, "u": {}}


### PR DESCRIPTION
## Summary
- Implement recursive `serde_json::Value` → Python conversion in `src/schema.rs` (dict/list/scalars/null).
- Use the direct converter for `json=` and `claims=` kwargs in dispatch (no intermediate JSON string).
- Add integration tests for nested JSON body types.

Closes #95

## Test plan
- [x] `uv run pytest tests/test_json_body.py tests/test_jwt_parity.py`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Maintainer: `make test`