### PR TITLE
perf(config): cache OXYROUTE_* environment flags

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -33,7 +33,7 @@ Register routes with `read_form_body=True` on `post` / `put` / `patch` (and `del
 - **`Content-Type: application/x-www-form-urlencoded`** — the body is parsed like a query string (percent-decoding, `+` as space).
 - **`Content-Type: multipart/form-data; boundary=...`** — parts with a **filename** are collected as `files`; other parts go into `form`.
 - Wrong or missing `Content-Type` when the body is non-empty → **400** (missing type) or **415** (not a form type). Malformed multipart → **400** with a JSON error.
-- **Size limit:** the full body is buffered in memory before parsing. The default maximum is **8 MiB**; override with the environment variable **`OXYROUTE_MAX_BODY_BYTES`** (set to `0` to disable the check—**not recommended** in production). Oversized bodies → **413** with `{"error":"payload too large"}`.
+- **Size limit:** the full body is buffered in memory before parsing. The default maximum is **8 MiB**; override with the environment variable **`OXYROUTE_MAX_BODY_BYTES`** (set to `0` to disable the check—**not recommended** in production). The value is read once on first body handling in a worker process. Oversized bodies → **413** with `{"error":"payload too large"}`.
 
 Only parameters that appear in the handler signature (or `**kwargs`) receive `form` / `files`, the same as for `query` and dependencies.
 
@@ -77,7 +77,7 @@ raise HTTPException(400, "bad", headers={"X-Reason": "check"})  # optional extra
 
 If a **dependency factory** or the **route handler** raises any other Python exception (or building the response fails), the server answers with **500** and a small **JSON** body: `{"error":"internal server error"}`. Exception text and tracebacks are **not** included in the response by default (to avoid leaking internals to clients).
 
-Set the environment variable **`OXYROUTE_DEBUG=1`** (or `true`) to include a **`detail`** string in that JSON for the same error and to log more at the `log` crate target **`oxyroute`** (see `RUST_LOG`, e.g. `RUST_LOG=oxyroute=error`).
+Set the environment variable **`OXYROUTE_DEBUG=1`** (or `true`) to include a **`detail`** string in that JSON for the same error and to log more at the `log` crate target **`oxyroute`** (see `RUST_LOG`, e.g. `RUST_LOG=oxyroute=error`). Like body limits, this flag is read once on the first error path in a worker process.
 
 There is no **`register_exception_handler`** API yet; map custom exception types by catching them in Python or by a small wrapper.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,33 @@
+//! Runtime configuration from environment variables (read once on first use).
+
+use std::sync::OnceLock;
+
+fn parse_bool_env(v: &str) -> bool {
+    v == "1" || v.eq_ignore_ascii_case("true")
+}
+
+/// When true, HTTP 500 responses may include exception detail (``OXYROUTE_DEBUG=1`` / ``true``).
+pub fn oxyroute_debug() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("OXYROUTE_DEBUG")
+            .map(|v| parse_bool_env(&v))
+            .unwrap_or(false)
+    })
+}
+
+/// Maximum request body size in bytes (``OXYROUTE_MAX_BODY_BYTES``). Default 8 MiB; ``0`` = no limit.
+pub fn max_body_bytes() -> u64 {
+    const DEFAULT: u64 = 8 * 1024 * 1024;
+    static CACHE: OnceLock<u64> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        match std::env::var("OXYROUTE_MAX_BODY_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+        {
+            None => DEFAULT,
+            Some(0) => u64::MAX,
+            Some(n) => n,
+        }
+    })
+}

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -9,6 +9,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyString, PyTuple};
 use serde_json::Value as JsonValue;
 
+use crate::config;
 use crate::form::{self, ParsedFile};
 use crate::params::{build_request_context, header_get_lax, parse_query, value_for_path_param};
 use crate::response;
@@ -23,9 +24,7 @@ use crate::websocket::WebSocket;
 type HttpExceptionPayload = (u16, Vec<u8>, Vec<(String, String)>);
 
 fn oxyroute_debug() -> bool {
-    std::env::var("OXYROUTE_DEBUG")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+    config::oxyroute_debug()
 }
 
 fn contains_crlf(s: &str) -> bool {

--- a/src/form.rs
+++ b/src/form.rs
@@ -69,13 +69,5 @@ pub async fn parse_multipart(body: Vec<u8>, boundary: &str) -> Result<ParsedForm
 
 /// Default 8 MiB; ``0`` = no limit (not recommended in production). Override with env ``OXYROUTE_MAX_BODY_BYTES``.
 pub fn max_body_bytes() -> u64 {
-    const DEFAULT: u64 = 8 * 1024 * 1024;
-    match std::env::var("OXYROUTE_MAX_BODY_BYTES")
-        .ok()
-        .and_then(|s| s.parse().ok())
-    {
-        None => DEFAULT,
-        Some(0) => u64::MAX,
-        Some(n) => n,
-    }
+    crate::config::max_body_bytes()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
 use serde_json::json;
 
+mod config;
 mod dispatch;
 mod form;
 mod params;

--- a/tests/test_form_body.py
+++ b/tests/test_form_body.py
@@ -55,33 +55,42 @@ def test_multipart_file_and_field() -> None:
 
 
 def test_payload_too_large_413() -> None:
-    app = App()
+    """Isolated process: ``OXYROUTE_MAX_BODY_BYTES`` is cached on first body read."""
+    import subprocess
+    import sys
+    from pathlib import Path
 
-    @app.post("/b", read_form_body=True)
-    def b(form: dict) -> str:
-        return "ok" if not form else "bad"
+    repo = Path(__file__).resolve().parents[1]
+    code = """
+import asyncio
+import os
 
-    old = os.environ.get("OXYROUTE_MAX_BODY_BYTES")
-    os.environ["OXYROUTE_MAX_BODY_BYTES"] = "20"
-    try:
+import httpx
+from oxyroute import App
+from tests._rsgi_test_transport import asgi_test_app
 
-        async def _run() -> None:
-            transport = httpx.ASGITransport(app=asgi_test_app(app))
-            async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
-                r = await c.post(
-                    "/b",
-                    content="x" * 100,
-                    headers={"content-type": "application/x-www-form-urlencoded"},
-                )
-            assert r.status_code == 413
-            err = (
-                r.json() if r.headers.get("content-type", "").startswith("application/json") else {}
-            )
-            assert err.get("error") == "payload too large" or "payload" in (r.text or "")
+os.environ["OXYROUTE_MAX_BODY_BYTES"] = "20"
 
-        asyncio.run(_run())
-    finally:
-        if old is None:
-            del os.environ["OXYROUTE_MAX_BODY_BYTES"]
-        else:
-            os.environ["OXYROUTE_MAX_BODY_BYTES"] = old
+app = App()
+
+@app.post("/b", read_form_body=True)
+def b(form: dict) -> str:
+    return "ok" if not form else "bad"
+
+async def main() -> None:
+    transport = httpx.ASGITransport(app=asgi_test_app(app))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/b",
+            content="x" * 100,
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+    assert r.status_code == 413
+    err = r.json() if r.headers.get("content-type", "").startswith("application/json") else {}
+    assert err.get("error") == "payload too large" or "payload" in (r.text or "")
+
+asyncio.run(main())
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo)
+    subprocess.run([sys.executable, "-c", code], env=env, check=True, cwd=repo)

--- a/tests/test_handler_errors_500.py
+++ b/tests/test_handler_errors_500.py
@@ -46,22 +46,43 @@ def test_500_no_exception_text_by_default() -> None:
 
 
 def test_500_includes_detail_when_debug_env() -> None:
-    os.environ["OXYROUTE_DEBUG"] = "1"
-    app = _make_app()
-    try:
+    """Isolated process: ``OXYROUTE_DEBUG`` is cached on first error path."""
+    import subprocess
+    import sys
+    from pathlib import Path
 
-        async def _run() -> None:
-            transport = httpx.ASGITransport(app=asgi_test_app(app))
-            async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-                r = await c.get("/boom")
-            assert r.status_code == 500
-            data = json.loads(r.text)
-            assert "detail" in data
-            assert "super_secret_token" in data["detail"] or "ValueError" in data["detail"]
+    repo = Path(__file__).resolve().parents[1]
+    code = """
+import asyncio
+import json
+import os
 
-        asyncio.run(_run())
-    finally:
-        os.environ.pop("OXYROUTE_DEBUG", None)
+import httpx
+from oxyroute import App
+from tests._rsgi_test_transport import asgi_test_app
+
+os.environ["OXYROUTE_DEBUG"] = "1"
+
+app = App()
+
+@app.get("/boom")
+def boom() -> str:
+    raise ValueError("super_secret_token")
+
+async def main() -> None:
+    transport = httpx.ASGITransport(app=asgi_test_app(app))
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/boom")
+    assert r.status_code == 500
+    data = json.loads(r.text)
+    assert "detail" in data
+    assert "super_secret_token" in data["detail"] or "ValueError" in data["detail"]
+
+asyncio.run(main())
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo)
+    subprocess.run([sys.executable, "-c", code], env=env, check=True, cwd=repo)
 
 
 def test_dependency_error_returns_500() -> None:


### PR DESCRIPTION
## Summary
- Add `src/config.rs` with `OnceLock` caches for `OXYROUTE_MAX_BODY_BYTES` and `OXYROUTE_DEBUG`.
- Delegate from `form::max_body_bytes` and dispatch error handling.
- Document first-use semantics in `docs/handlers.md`.
- Run env-mutating tests in isolated subprocesses so they remain valid with caching.

Closes #97

## Test plan
- [x] `uv run pytest tests/test_form_body.py tests/test_handler_errors_500.py`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Maintainer: `make test`